### PR TITLE
feat: TurboQuantDB v0.1.0 — storage engine, ANN index, quantizer, CI/CD, and Python API

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   # ── Linux (manylinux) ───────────────────────────────────────────────────────
+  # manylinux containers ship CPython 3.10–3.13; no setup-python needed.
   linux:
     name: Linux wheels (${{ matrix.target }})
     runs-on: ubuntu-latest
@@ -18,14 +19,6 @@ jobs:
         target: [x86_64, aarch64]
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: |
-            "3.10"
-            "3.11"
-            "3.12"
-            "3.13"
 
       - name: Build manylinux wheels
         uses: PyO3/maturin-action@v1
@@ -41,19 +34,19 @@ jobs:
           path: dist
 
   # ── Windows ─────────────────────────────────────────────────────────────────
+  # setup-python only accepts a single version; use a matrix to install each.
   windows:
-    name: Windows wheels
+    name: Windows wheels (Python ${{ matrix.python-version }})
     runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: |
-            "3.10"
-            "3.11"
-            "3.12"
-            "3.13"
+          python-version: ${{ matrix.python-version }}
 
       - name: Build Windows wheels
         uses: PyO3/maturin-action@v1
@@ -64,26 +57,24 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-windows-x86_64
+          name: wheels-windows-x86_64-py${{ matrix.python-version }}
           path: dist
 
   # ── macOS ────────────────────────────────────────────────────────────────────
+  # setup-python only accepts a single version; use a matrix to install each.
   macos:
-    name: macOS wheels (${{ matrix.target }})
+    name: macOS wheels (${{ matrix.target }}, Python ${{ matrix.python-version }})
     runs-on: macos-latest
     strategy:
       matrix:
         target: [x86_64, aarch64]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: |
-            "3.10"
-            "3.11"
-            "3.12"
-            "3.13"
+          python-version: ${{ matrix.python-version }}
 
       - name: Build macOS wheels
         uses: PyO3/maturin-action@v1
@@ -94,7 +85,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-macos-${{ matrix.target }}
+          name: wheels-macos-${{ matrix.target }}-py${{ matrix.python-version }}
           path: dist
 
   # ── Source distribution ──────────────────────────────────────────────────────

--- a/src/quantizer/mod.rs
+++ b/src/quantizer/mod.rs
@@ -5,7 +5,7 @@
 //! 1. [`mse::MseQuantizer`] — Applies a seeded SRHT rotation, then encodes each
 //!    dimension using a Lloyd-Max scalar codebook (b-1 bits per dimension).
 //! 2. [`qjl::QjlQuantizer`] — Projects the MSE residual via a dense Gaussian
-//!    SRHT and stores the sign bit (1 bit per dimension, bit-packed).
+//!    matrix and stores the sign bit (1 bit per dimension, bit-packed).
 //! 3. [`prod::ProdQuantizer`] — Orchestrates both stages, manages lookup tables
 //!    for fast asymmetric inner-product scoring, and exposes batch encode/decode.
 //!

--- a/src/storage/backend.rs
+++ b/src/storage/backend.rs
@@ -129,7 +129,7 @@ pub struct StorageBackend {
 
 impl StorageBackend {
     pub fn from_uri(uri: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
-        if uri.starts_with("s3://") || uri.starts_with("gs://") {
+        if uri.starts_with("s3://") || uri.starts_with("gs://") || uri.starts_with("az://") {
             return Err("Cloud storage requires the 'cloud' feature. Phase 4 provides local-first stability.".into());
         }
 

--- a/src/storage/live_codes.rs
+++ b/src/storage/live_codes.rs
@@ -90,6 +90,12 @@ impl LiveCodesFile {
     }
 
     pub fn alloc_slot(&mut self) -> Result<usize, Box<dyn std::error::Error + Send + Sync>> {
+        // Re-establish mmap if handles were released (e.g. after release_handles())
+        // and we still have capacity — growth path already calls ensure_open + remap.
+        if self.mmap.is_none() && self.len < self.capacity {
+            self.ensure_open()?;
+            self.remap()?;
+        }
         if self.len >= self.capacity {
             let new_capacity = self.capacity + GROW_SLOTS;
             self.mmap = None; // mmap must be dropped before set_len on Windows

--- a/src/storage/metadata.rs
+++ b/src/storage/metadata.rs
@@ -119,6 +119,9 @@ impl MetadataStore {
         }
 
         writer.flush()?;
+        // On Windows, rename fails if the destination already exists.
+        #[cfg(target_os = "windows")]
+        let _ = std::fs::remove_file(&self.path);
         std::fs::rename(&tmp, &self.path)?;
         self.dirty = false;
         Ok(())


### PR DESCRIPTION
## Summary

- Full embedded vector database with TurboQuant two-stage quantization (MSE + QJL)
- HNSW ANN index with configurable `max_degree`, `ef_construction`, `n_refinements`
- Python API via PyO3/Maturin: `Database.open`, `insert_batch`, `search`, `create_index`, metadata filtering
- Apache 2.0 license, project renamed to TurboQuantDB, all URLs updated to `jyunming`
- CI/CD: `release.yml` builds wheels for Python 3.10–3.13 on Linux (x86_64/aarch64), Windows, macOS (x86_64/aarch64) + sdist; publishes to PyPI via `MATURIN_PYPI_TOKEN`
- Docs: `README.md` and `docs/PYTHON_API.md` rewritten with accurate API (including `rerank_precision`), anonymized benchmark comparison, server mode marked experimental
- Benchmarks: pre-embedded DBpedia dataset harness, process-isolated measurement, checkpoint-based

## Test plan

- [x] `cargo test -q --lib` passes
- [x] `maturin develop --release && python benchmarks/ci_quality_gate.py` passes recall gate (≥0.60) and latency gate (≤100ms)
- [x] After merge, push `v0.1.0` tag to trigger PyPI publish (requires `PYPI_API_TOKEN` secret set in repo settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)