### PR TITLE
fix(release): pin Linux manylinux interpreters to CPython 3.10-3.13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           target: ${{ matrix.target }}
           manylinux: auto
-          args: --release --out dist --find-interpreter
+          args: --release --out dist -i 3.10 -i 3.11 -i 3.12 -i 3.13
           sccache: "true"
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Problem
\--find-interpreter\ in the manylinux container picks up **PyPy 3.11** and **CPython 3.14** in addition to 3.10–3.13. PyO3 0.21.2 doesn't support either, so the x86_64 Linux build fails even though the CPython 3.10–3.13 wheels build fine.

## Fix
Replace \--find-interpreter\ with explicit \-i 3.10 -i 3.11 -i 3.12 -i 3.13\ for the Linux manylinux job. aarch64 still has \continue-on-error: true\ for the separate mimalloc/GCC cross-compile issue.

## After merge
Delete and re-push the \0.1.0\ tag to trigger a clean release run.