### PR TITLE
perf(engine): parallel batch ingest via Rayon with sequential fallback

### DIFF
--- a/benchmarks/perf_baseline.json
+++ b/benchmarks/perf_baseline.json
@@ -28,15 +28,15 @@
     },
     "avg_latency_ms": {
       "higher_is_better": false,
-      "best": 3.0453319975640625
+      "best": 1.218922003172338
     },
     "p50_latency_ms": {
       "higher_is_better": false,
-      "best": 3.0377999937627465
+      "best": 1.2219500204082578
     },
     "p95_latency_ms": {
       "higher_is_better": false,
-      "best": 3.1346550036687404
+      "best": 1.2717700214125216
     },
     "disk_bytes": {
       "higher_is_better": false,

--- a/src/quantizer/prod.rs
+++ b/src/quantizer/prod.rs
@@ -482,7 +482,14 @@ impl ProdQuantizer {
     }
 
     pub fn quantize_batch(&self, xs: &[&[f32]]) -> Vec<(Vec<CodeIndex>, Vec<u8>, f64)> {
-        xs.par_iter().map(|x| self.quantize(x)).collect()
+        // Below this threshold the Rayon thread-park/unpark overhead exceeds the
+        // quantization work on all supported platforms (especially Windows).
+        const PAR_THRESHOLD: usize = 512;
+        if xs.len() <= PAR_THRESHOLD {
+            xs.iter().map(|x| self.quantize(x)).collect()
+        } else {
+            xs.par_iter().map(|x| self.quantize(x)).collect()
+        }
     }
 
     pub fn dequantize(&self, idx: &[CodeIndex], qjl: &[u8], gamma: f64) -> Array1<f64> {

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -2474,17 +2474,34 @@ impl TurboQuantEngine {
             // Normalize each vector to unit sphere before quantization so the
             // Lloyd-Max codebook (fitted to Beta-distribution unit-sphere coords) is valid.
             // Compute (unit_vec, norm) once to avoid a second O(d) pass per vector.
-            let unit_vecs_and_norms: Vec<(Vec<f32>, f32)> = chunk
-                .iter()
-                .map(|item| {
-                    let n = item.vector.iter().map(|x| x * x).sum::<f32>().sqrt();
-                    if n > 1e-10 {
-                        (item.vector.iter().map(|&x| x / n).collect(), n)
-                    } else {
-                        (item.vector.clone(), n)
-                    }
-                })
-                .collect();
+            // Use Rayon for large chunks; sequential for small ones to avoid
+            // thread park/unpark overhead (same threshold as quantize_batch).
+            const NORM_PAR_THRESHOLD: usize = 512;
+            let unit_vecs_and_norms: Vec<(Vec<f32>, f32)> = if chunk.len() > NORM_PAR_THRESHOLD {
+                chunk
+                    .par_iter()
+                    .map(|item| {
+                        let n = item.vector.iter().map(|x| x * x).sum::<f32>().sqrt();
+                        if n > 1e-10 {
+                            (item.vector.iter().map(|&x| x / n).collect(), n)
+                        } else {
+                            (item.vector.clone(), n)
+                        }
+                    })
+                    .collect()
+            } else {
+                chunk
+                    .iter()
+                    .map(|item| {
+                        let n = item.vector.iter().map(|x| x * x).sum::<f32>().sqrt();
+                        if n > 1e-10 {
+                            (item.vector.iter().map(|&x| x / n).collect(), n)
+                        } else {
+                            (item.vector.clone(), n)
+                        }
+                    })
+                    .collect()
+            };
             let vec_refs: Vec<&[f32]> = unit_vecs_and_norms
                 .iter()
                 .map(|(v, _)| v.as_slice())


### PR DESCRIPTION
## Summary

- `quantize_batch()` adds a `PAR_THRESHOLD=512` guard — small batches (≤512 vectors) use sequential `iter` to avoid Rayon thread park/unpark overhead (especially on Windows); large batches continue using `par_iter`
- `insert_many_with_mode()` parallelizes the L2-normalization step for batches >512 via `par_iter`; WAL append, live-codes writes, and metadata writes remain sequential (require `&mut self` or are I/O bound)

## Related issues

Closes #17

## Changes

- `src/quantizer/prod.rs` — `quantize_batch()` seq threshold guard
- `src/storage/engine/mod.rs` — parallel normalization in `insert_many_with_mode`

## Test plan

- [x] `cargo test -q --lib` passes (319 tests)
- [x] Pre-commit perf gate passes; ingest throughput stable at ~70k vps on test set
- [x] No correctness regressions (normalization + quantization results are identical)