### PR TITLE
chore(release): bump version to 0.4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tqdb"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 license = "Apache-2.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tqdb"
-version = "0.3.0"
+version = "0.4.0"
 description = "Embedded vector database using the TurboQuant algorithm (arXiv:2504.19874) — zero training, 2-4 bit compression, fast inner-product search"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Bump pyproject.toml version 0.3.0 → 0.4.0.

feat commits present in this sprint → MINOR bump per versioning policy.

After merging, push the tag to trigger wheel builds + PyPI publish + website/CHANGELOG auto-update:

    git tag v0.4.0
    GITHUB_TOKEN="" git push origin v0.4.0