### PR TITLE
chore(release): bump version badge and CHANGELOG for v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,28 @@ Format: `[version] — type(scope): summary`. Commits use [Conventional Commits]
 
 ---
 
+## [0.4.0] — 2026-04-08
+
+### Added
+- Delta overlay: vectors inserted after `create_index()` are tracked in a persisted `delta_ids.json` and merged into ANN search results without requiring a graph rebuild
+- Parallel ingest: Rayon-based quantization/normalization for large batches with sequential fallback for small ones
+
+### Fixed
+- Compaction crash recovery: segments written to `.tmp` then atomically renamed; orphan `.tmp` files cleaned on startup
+- ANN delta filter: replaced per-query `HashSet` allocation with `is_slot_alive()` O(1) check
+- `maybe_persist_state`: delta slots written to both `local_dir` and backend to prevent stale local file winning on reopen
+- S3 `rename`: switched to server-side `store.copy()` (no RAM spike) with crash-safe ordering
+- `release.yml`: `id-token: write` added to `release` job — was overridden by job-level permissions block, breaking OIDC publish
+
+### Performance
+- Batch insert: `indexed_set` built once per batch (not per chunk) — O(batch + indexed) instead of O(chunks × indexed)
+- Single-vector insert: `binary_search` O(log n) instead of `Vec::contains` O(n); `delta_slots` maintained sorted
+
+### Changed
+- `.unwrap()` audit: replaced with `.expect()` on all write/search paths for clearer panic messages
+
+---
+
 ## [0.3.0] — 2026-04-07
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tqdb"
-version = "0.3.0"
+version = "0.4.0"
 description = "Embedded vector database using the TurboQuant algorithm (arXiv:2504.19874) — zero training, 2-4 bit compression, fast inner-product search"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/website/index.html
+++ b/website/index.html
@@ -32,7 +32,7 @@
 
     <header class="hero">
         <div class="hero-content fade-in-up">
-            <div class="badge">v0.3.0 Released</div>
+            <div class="badge">v0.4.0 Released</div>
             <h1 class="hero-title">Massive embedding datasets.<br>Lightweight hardware.</h1>
             <p class="hero-subtitle">
                 An embedded vector database in Rust with Python bindings. Implementing the <strong>TurboQuant algorithm</strong> for zero-training, 2–4 bit compression, and unbiased inner product estimation.


### PR DESCRIPTION
Manual docs update for v0.4.0 — the release workflow's update-docs job failed due to branch protection (fixed in PR #26). This PR updates website/index.html badge to v0.4.0 Released and prepends the v0.4.0 entry to CHANGELOG.md.