### PR TITLE
fix(ci): switch macOS to universal2 wheels, fix aarch64 server binary linker

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,26 +91,23 @@ jobs:
           path: dist
 
   # ── macOS ────────────────────────────────────────────────────────────────────
-  # `macos-latest` is ARM64 (M-series).  We need an Intel (x86_64) runner
-  # for x86_64 targets so setup-python installs an x86_64 Python framework —
-  # otherwise the linker can't find x86_64 Python C API symbols when
-  # cross-compiling from ARM64.
+  # GitHub retired the macos-13 Intel runner; macos-latest is ARM64 (M-series).
   #
-  # Matrix trick: declare `runner` per target via `include:` so each row
-  # automatically gets the correct runner.
+  # We build universal2 wheels (fat binary: x86_64 + aarch64) on macos-latest
+  # so a single wheel covers both Apple Silicon and Intel Macs.
+  #
+  # The server binary is compiled natively (no --target flag) to avoid a PyO3
+  # cross-compile detection bug: passing --target aarch64-apple-darwin on an
+  # aarch64 host triggers PyO3's cross-compile code path which fails to locate
+  # the Python framework, causing unresolved Python symbols at link time.
+  # The native binary is aarch64; Intel Mac users can build from source.
   macos:
-    name: macOS wheels (${{ matrix.target }}, Python ${{ matrix.python-version }})
-    runs-on: ${{ matrix.runner }}
+    name: macOS wheels (universal2, Python ${{ matrix.python-version }})
+    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
-        target: [x86_64, aarch64]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        include:
-          - target: x86_64
-            runner: macos-13       # last Intel runner; installs x86_64 Python
-          - target: aarch64
-            runner: macos-latest   # ARM64 (M-series)
     steps:
       - uses: actions/checkout@v4
 
@@ -118,27 +115,23 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # macos-latest is arm64; x86_64 requires cross-compilation.
-      # Build the server binary for the matching Apple target before maturin.
-      - name: Build and bundle server binary
+      - name: Build and bundle server binary (aarch64 native)
         shell: bash
         run: |
-          APPLE_TARGET="${{ matrix.target }}-apple-darwin"
-          rustup target add "$APPLE_TARGET" 2>/dev/null || true
-          cargo build --release --target "$APPLE_TARGET" --manifest-path server/Cargo.toml
+          cargo build --release --manifest-path server/Cargo.toml
           mkdir -p python/tqdb/_bin
-          cp "server/target/${APPLE_TARGET}/release/tqdb-server" python/tqdb/_bin/
+          cp server/target/release/tqdb-server python/tqdb/_bin/
 
-      - name: Build macOS wheels
+      - name: Build macOS wheels (universal2)
         uses: PyO3/maturin-action@v1
         with:
-          target: ${{ matrix.target }}
+          target: universal2-apple-darwin
           args: --release --out dist -i python
           sccache: "true"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-macos-${{ matrix.target }}-py${{ matrix.python-version }}
+          name: wheels-macos-universal2-py${{ matrix.python-version }}
           path: dist
 
   # ── Source distribution ──────────────────────────────────────────────────────


### PR DESCRIPTION
Fix macOS CI failures: retire macos-13 (dead runner), use universal2 on macos-latest, fix PyO3 cross-compile linker bug in server binary.