### PR TITLE
fix(ci): feature-gate PyO3 so server binary links on macOS

### DIFF
--- a/.github/workflows/benchmark-artifacts.yml
+++ b/.github/workflows/benchmark-artifacts.yml
@@ -8,6 +8,9 @@ on:
       - main
       - master
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,9 @@ jobs:
           RUSTFLAGS: "-D warnings"
         run: cargo check -q
 
+      - name: cargo check server (no Python features)
+        run: cargo check -q --manifest-path server/Cargo.toml
+
   python-smoke:
     name: Python smoke test
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -7,6 +7,9 @@ on:
       - "website/**"
   workflow_dispatch:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+
 permissions:
   contents: read
   pages: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,11 +96,10 @@ jobs:
   # We build universal2 wheels (fat binary: x86_64 + aarch64) on macos-latest
   # so a single wheel covers both Apple Silicon and Intel Macs.
   #
-  # The server binary is compiled natively (no --target flag) to avoid a PyO3
-  # cross-compile detection bug: passing --target aarch64-apple-darwin on an
-  # aarch64 host triggers PyO3's cross-compile code path which fails to locate
-  # the Python framework, causing unresolved Python symbols at link time.
-  # The native binary is aarch64; Intel Mac users can build from source.
+  # The server binary is compiled natively (no --target flag).  PyO3 is
+  # feature-gated behind the "python" Cargo feature (default-enabled) and
+  # server/Cargo.toml uses default-features = false, so the server links
+  # without any Python C-API symbols.
   macos:
     name: macOS wheels (universal2, Python ${{ matrix.python-version }})
     runs-on: macos-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1920,7 +1920,6 @@ dependencies = [
  "numpy",
  "object_store",
  "pyo3",
- "pyo3-build-config",
  "rand 0.8.5",
  "rand_distr",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,19 +33,18 @@ rayon = "1.10"
 matrixmultiply = "0.3"
 mimalloc = { version = "0.1", default-features = false }
 
-# --- Python Bindings ---
-pyo3 = { version = "0.21.0", features = ["extension-module"] }
-numpy = "0.21.0"
+# --- Python Bindings (optional; disabled for server binary) ---
+pyo3 = { version = "0.21.0", features = ["extension-module"], optional = true }
+numpy = { version = "0.21.0", optional = true }
 
 object_store = { version = "0.11", features = ["aws"], optional = true }
 tokio = { version = "1", features = ["rt", "macros"], optional = true }
 futures = { version = "0.3", optional = true }
 
 [features]
+default = ["python"]
+python = ["dep:pyo3", "dep:numpy"]
 cloud = ["object_store", "tokio", "futures"]
-
-[build-dependencies]
-pyo3-build-config = "0.21.0"
 
 [dev-dependencies]
 tempfile = "3.27.0"

--- a/benchmarks/perf_baseline.json
+++ b/benchmarks/perf_baseline.json
@@ -28,15 +28,15 @@
     },
     "avg_latency_ms": {
       "higher_is_better": false,
-      "best": 1.295930999913253
+      "best": 1.1103479989105836
     },
     "p50_latency_ms": {
       "higher_is_better": false,
-      "best": 1.292100001592189
+      "best": 1.1128999758511782
     },
     "p95_latency_ms": {
       "higher_is_better": false,
-      "best": 1.32571502472274
+      "best": 1.1487150157336146
     },
     "disk_bytes": {
       "higher_is_better": false,

--- a/benchmarks/perf_baseline.json
+++ b/benchmarks/perf_baseline.json
@@ -28,15 +28,15 @@
     },
     "avg_latency_ms": {
       "higher_is_better": false,
-      "best": 1.1103479989105836
+      "best": 1.295930999913253
     },
     "p50_latency_ms": {
       "higher_is_better": false,
-      "best": 1.1128999758511782
+      "best": 1.292100001592189
     },
     "p95_latency_ms": {
       "higher_is_better": false,
-      "best": 1.1487150157336146
+      "best": 1.32571502472274
     },
     "disk_bytes": {
       "higher_is_better": false,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ Issues = "https://github.com/jyunming/TurboQuantDB/issues"
 Changelog = "https://github.com/jyunming/TurboQuantDB/releases"
 
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["python", "pyo3/extension-module"]
 python-source = "python"
 include = ["python/tqdb/*.pyi", "python/tqdb/_bin/*"]
 

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -484,12 +484,6 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -727,15 +721,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -814,15 +799,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -866,15 +842,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
 ]
 
 [[package]]
@@ -1049,21 +1016,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "numpy"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec170733ca37175f5d75a5bea5911d6ff45d2cd52849ce98b685394e4f2f37f4"
-dependencies = [
- "libc",
- "ndarray",
- "num-complex",
- "num-integer",
- "num-traits",
- "pyo3",
- "rustc-hash",
-]
-
-[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,29 +1026,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "parking_lot"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
-]
 
 [[package]]
 name = "paste"
@@ -1157,69 +1086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "pyo3"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5e00b96a521718e08e03b1a622f01c8a8deb50719335de3f60b3b3950f069d8"
-dependencies = [
- "cfg-if",
- "indoc",
- "libc",
- "memoffset",
- "parking_lot",
- "portable-atomic",
- "pyo3-build-config",
- "pyo3-ffi",
- "pyo3-macros",
- "unindent",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7883df5835fafdad87c0d888b266c8ec0f4c9ca48a5bed6bbb592e8dedee1b50"
-dependencies = [
- "once_cell",
- "target-lexicon",
-]
-
-[[package]]
-name = "pyo3-ffi"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01be5843dc60b916ab4dad1dca6d20b9b4e6ddc8e15f50c47fe6d85f1fb97403"
-dependencies = [
- "libc",
- "pyo3-build-config",
-]
-
-[[package]]
-name = "pyo3-macros"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77b34069fc0682e11b31dbd10321cbf94808394c56fd996796ce45217dfac53c"
-dependencies = [
- "proc-macro2",
- "pyo3-macros-backend",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pyo3-macros-backend"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08260721f32db5e1a5beae69a55553f56b99bd0e1c3e6e0a5e8851a9d0f5a85c"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "pyo3-build-config",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -1363,15 +1229,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex-automata"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1401,12 +1258,6 @@ dependencies = [
  "untrusted",
  "windows-sys 0.52.0",
 ]
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustix"
@@ -1498,12 +1349,6 @@ checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
@@ -1697,12 +1542,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "target-lexicon"
-version = "0.12.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
-
-[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,7 +1672,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tqdb"
-version = "0.4.0"
+version = "0.5.1"
 dependencies = [
  "bincode",
  "crc32fast",
@@ -1843,9 +1682,6 @@ dependencies = [
  "mimalloc",
  "nalgebra",
  "ndarray",
- "numpy",
- "pyo3",
- "pyo3-build-config",
  "rand 0.8.5",
  "rand_distr",
  "rayon",
@@ -1969,12 +1805,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"
@@ -2280,7 +2110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -2291,7 +2121,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "prettyplease",
  "syn",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -11,7 +11,7 @@ serde_json = "1"
 tower = "0.5"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-tqdb = { path = ".." }
+tqdb = { path = "..", default-features = false }
 ndarray = "0.15"
 metrics = "0.23"
 metrics-exporter-prometheus = "0.15"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -12,7 +12,7 @@ use std::collections::{HashMap, HashSet};
 use std::net::SocketAddr;
 use std::path::{Path as StdPath, PathBuf};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tqdb::storage::engine::{BatchWriteItem, DistanceMetric, GetResult, TurboQuantEngine};
 use tracing::{error, info};
 
@@ -3089,7 +3089,7 @@ mod tests {
                 }
                 Err(err) => {
                     if err.to_string().contains("EOF while parsing a value") {
-                        std::thread::sleep(Duration::from_millis(10));
+                        std::thread::sleep(std::time::Duration::from_millis(10));
                         open_err = Some(err.to_string());
                         continue;
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,13 +37,16 @@
 //! - **Embedded** (`tqdb` Python package) — runs in-process, no server needed.
 //! - **Server** (`server/` workspace) — Axum HTTP service with multi-tenancy, RBAC, quotas.
 
+#[cfg(feature = "python")]
 use pyo3::prelude::*;
 
 pub mod linalg;
+#[cfg(feature = "python")]
 pub mod python;
 pub mod quantizer;
 pub mod storage;
 
+#[cfg(feature = "python")]
 #[pymodule]
 fn tqdb(py: Python, m: &Bound<'_, PyModule>) -> PyResult<()> {
     python::register(py, m)?;

--- a/src/storage/engine/filter.rs
+++ b/src/storage/engine/filter.rs
@@ -151,6 +151,7 @@ pub(crate) fn apply_comparison_op(field: Option<&JsonValue>, op: &str, op_val: &
     }
 }
 
+#[allow(dead_code)]
 const KNOWN_COMPARISON_OPS: &[&str] = &[
     "$eq",
     "$ne",
@@ -166,15 +167,18 @@ const KNOWN_COMPARISON_OPS: &[&str] = &[
 
 /// Recursively validate that all operator keys in `filter` are known.
 /// Returns `Err(message)` on the first unknown operator encountered.
+#[allow(dead_code)]
 pub(crate) fn validate_filter_operators(filter: &HashMap<String, JsonValue>) -> Result<(), String> {
     validate_filter_operators_obj(filter.iter().map(|(k, v)| (k.as_str(), v)))
 }
 
 /// Internal helper that accepts a `serde_json::Map` reference to avoid cloning.
+#[allow(dead_code)]
 fn validate_filter_operators_inner(map: &serde_json::Map<String, JsonValue>) -> Result<(), String> {
     validate_filter_operators_obj(map.iter().map(|(k, v)| (k.as_str(), v)))
 }
 
+#[allow(dead_code)]
 fn validate_filter_operators_obj<'a>(
     iter: impl Iterator<Item = (&'a str, &'a JsonValue)>,
 ) -> Result<(), String> {


### PR DESCRIPTION
## Problem

All 4 macOS release jobs fail with unresolved Python C-API symbols when linking the server binary:

`
Undefined symbols for architecture arm64:
  _PyBaseObject_Type, _PyBool_Type, _PyBytes_Type, _PyDict_Type, ...
`

**Root cause:** `pyo3` is an unconditional dependency in `Cargo.toml`. PyO3's `extension-module` feature emits `-undefined dynamic_lookup` only for cdylib targets (the Python extension), **not** for bin targets (the server). On macOS the linker is strict about undefined symbols → hard error.

Linux succeeds because the ELF linker tolerates undefined symbols; Windows succeeds because MSVC uses `/FORCE:UNRESOLVED`.

## Fix

Feature-gate PyO3 behind a default-enabled `python` Cargo feature:

| File | Change |
|------|--------|
| `Cargo.toml` | `pyo3` and `numpy` → `optional = true`; new `python = ["dep:pyo3", "dep:numpy"]` feature (default-enabled); remove unused `pyo3-build-config` build-dep |
| `src/lib.rs` | Wrap `use pyo3`, `pub mod python`, `#[pymodule]` in `#[cfg(feature = "python")]` |
| `server/Cargo.toml` | `tqdb = { path = "..", default-features = false }` — server never pulls in PyO3 |
| `pyproject.toml` | Add `python` to `[tool.maturin].features` so maturin enables the feature for wheel builds |
| `release.yml` | Updated macOS comments to reflect the real fix |
| `ci.yml` | Added `cargo check --manifest-path server/Cargo.toml` step to catch regressions |

## Verification

- `cargo check -q` ✅ (default features, with PyO3)
- `cargo check -q --manifest-path server/Cargo.toml` ✅ (no PyO3, no Python symbols)
- `cargo test -q --lib` ✅ (350 tests pass)
- Pre-commit perf gate ✅ (all metrics within tolerance)

Closes the macOS linker failure from runs [24318289483](https://github.com/jyunming/TurboQuantDB/actions/runs/24318289483) and [24318034243](https://github.com/jyunming/TurboQuantDB/actions/runs/24318034243).