### PR TITLE
docs: comprehensive audit and update for v0.5.1

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,6 +30,9 @@ cargo fmt
 
 # Build distributable wheel
 maturin build --release --locked
+
+# Build optional HTTP server (server/Cargo.toml uses default-features = false to exclude PyO3)
+cd server && cargo build --release
 ```
 
 ## Testing
@@ -64,7 +67,7 @@ python benchmarks/compare_quantizers_paper.py
 ## Sprint / PR workflow
 
 One PR per sprint. All issues for a sprint go onto a single branch (e.g. `feat/v0.5-sprint`)
-and are merged via one PR. See `docs/sprint_process.md` for the full workflow.
+and are merged via one PR. See `CLAUDE.md` for the full workflow.
 
 ## Git identity
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -67,7 +67,7 @@ python benchmarks/compare_quantizers_paper.py
 ## Sprint / PR workflow
 
 One PR per sprint. All issues for a sprint go onto a single branch (e.g. `feat/v0.5-sprint`)
-and are merged via one PR. See `CLAUDE.md` for the full workflow.
+and are merged via one PR. See `CONTRIBUTING.md` for the full workflow.
 
 ## Git identity
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,8 @@ db = Database.open(path, dimension, bits=4, seed=42, metric="ip",
                    rerank=True, fast_mode=False, rerank_precision=None,
                    collection=None, wal_flush_threshold=None,
                    quantizer_type=None)  # None/"dense" = default (Haar QR + Gaussian); "srht" = fast O(d log d) ingest
-# NOTE: rerank=True stores raw f16 vectors for exact second-pass rescoring.
+# NOTE: rerank=True stores raw INT8 vectors (default) for exact second-pass rescoring.
+#       Use rerank_precision="f16" for float16 or "f32" for full precision.
 #       rerank_factor (default 10× brute / 20× ANN) controls oversampling.
 
 # Write

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ db = Database.open(path, dimension, bits=4, seed=42, metric="ip",
                    rerank=True, fast_mode=False, rerank_precision=None,
                    collection=None, wal_flush_threshold=None,
                    quantizer_type=None)  # None/"dense" = default (Haar QR + Gaussian); "srht" = fast O(d log d) ingest
-# NOTE: rerank=True stores raw INT8 vectors (default) for exact second-pass rescoring.
-#       Use rerank_precision="f16" for float16 or "f32" for full precision.
+# NOTE: rerank=True with rerank_precision=None uses per-vector-scaled INT8 reranking (default),
+#       which is approximate. Use rerank_precision="f16" or "f32" for higher-precision rescoring.
 #       rerank_factor (default 10× brute / 20× ANN) controls oversampling.
 
 # Write

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -21,7 +21,7 @@ This matrix tracks practical API/behavior parity against common embedded RAG vec
 | Pagination controls | Yes | `offset`/`limit` (where applicable). |
 | Distance metrics | Yes | `ip`, `cosine`, `l2` (collection-configured). |
 | ANN build + tuning | Yes | Graph index build/search controls and persisted index state. |
-| Snapshot | Yes | Engine + service job-based snapshot workflow. Restore is not implemented in server mode. |
+| Snapshot / Restore | Yes | Engine + service job-based snapshot and restore workflow via background jobs. |
 | Multi-tenant service auth/RBAC | Yes | Persisted API keys, principals, role bindings. |
 | Quota controls | Yes | Collections, vectors, disk, concurrent jobs. |
 

--- a/docs/SERVER_API.md
+++ b/docs/SERVER_API.md
@@ -419,7 +419,7 @@ Response `200` — job record nested under `"job"`:
 }
 ```
 
-`job_type` values: `"compact"`, `"index_build"`, `"snapshot"`
+`job_type` values: `"compact"`, `"index_build"`, `"snapshot"`, `"restore"`
 
 `status` values: `"queued"`, `"running"`, `"succeeded"`, `"failed"`, `"canceled"`
 

--- a/docs/SERVER_API.md
+++ b/docs/SERVER_API.md
@@ -347,7 +347,7 @@ Response `202`:
 
 ### `GET /metrics`
 
-Returns Prometheus text-format metrics. **No authentication required.**
+Returns Prometheus text-format metrics. **Authentication required** (`Authorization: ApiKey <key>`).
 
 ```
 Content-Type: text/plain; version=0.0.4; charset=utf-8

--- a/docs/SERVER_DESIGN.md
+++ b/docs/SERVER_DESIGN.md
@@ -130,15 +130,23 @@ Core endpoints:
 - `POST /v1/tenants/{tenant}/databases/{db}/collections`
 - `GET /v1/tenants/{tenant}/databases/{db}/collections`
 - `DELETE /v1/tenants/{tenant}/databases/{db}/collections/{collection}`
+- `POST /v1/.../{collection}/add`
 - `POST /v1/.../{collection}/upsert`
+- `POST /v1/.../{collection}/delete`
+- `POST /v1/.../{collection}/get`
 - `POST /v1/.../{collection}/query`
-- `POST /v1/.../{collection}/search`
+- `POST /v1/.../{collection}/compact`
 - `POST /v1/.../{collection}/index`
 - `POST /v1/.../{collection}/snapshot`
+- `POST /v1/.../{collection}/restore`
+- `GET /v1/tenants/{tenant}/databases/{db}/quota_usage`
+- `GET /metrics`
 
 Job endpoints:
 
 - `GET /v1/jobs/{job_id}`
+- `POST /v1/jobs/{job_id}/cancel`
+- `POST /v1/jobs/{job_id}/retry`
 - `GET /v1/.../{collection}/jobs`
 
 Error format:
@@ -265,7 +273,7 @@ Risk: background job contention with foreground writes.
 
 1. [x] Document the server API — see `docs/SERVER_API.md`.
 2. [x] Scaffold `server` crate with routing, auth middleware, and request context.
-3. Implement tenant/database path resolver and catalog helpers in storage layer.
+3. [x] Implement tenant/database path resolver and catalog helpers in storage layer.
 
 
 

--- a/server/README.md
+++ b/server/README.md
@@ -28,6 +28,7 @@ cargo build --release
 
 ### Health
 - `GET /healthz`
+- `GET /metrics` — Prometheus text metrics (no auth required)
 - `GET/POST /v1/tenants/:tenant/databases/:database/collections`
 - `DELETE /v1/tenants/:tenant/databases/:database/collections/:collection`
 - `POST /v1/tenants/:tenant/databases/:database/collections/:collection/add`
@@ -38,7 +39,9 @@ cargo build --release
 - `POST /v1/tenants/:tenant/databases/:database/collections/:collection/compact`
 - `POST /v1/tenants/:tenant/databases/:database/collections/:collection/index`
 - `POST /v1/tenants/:tenant/databases/:database/collections/:collection/snapshot`
+- `POST /v1/tenants/:tenant/databases/:database/collections/:collection/restore`
 - `GET /v1/tenants/:tenant/databases/:database/collections/:collection/jobs`
+- `GET /v1/tenants/:tenant/databases/:database/quota_usage`
 - `GET /v1/jobs/:job_id`
 - `POST /v1/jobs/:job_id/cancel`
 - `POST /v1/jobs/:job_id/retry`
@@ -59,6 +62,7 @@ cargo build --release
 - `POST .../compact` — Start background compaction
 - `POST .../index` — Start background HNSW index build
 - `POST .../snapshot` — Start background snapshot
+- `POST .../restore` — Start background restore from a snapshot
 - `GET .../jobs` — List jobs for a collection
 - `GET /v1/jobs/:job_id` — Get job status
 - `POST /v1/jobs/:job_id/cancel` — Cancel a job
@@ -68,7 +72,7 @@ cargo build --release
 
 - **Authentication** — API keys with RBAC scoped to tenant/database/collection level, persisted in `auth_store.json`
 - **Quotas** — Per-collection limits on vector count, disk bytes, and concurrent jobs, persisted in `quota_store.json`
-- **Async jobs** — Compaction, index build, and snapshots run in background workers; restart-safe with up to 3 retry attempts, state persisted in `job_store.json`
+- **Async jobs** — Compaction, index build, snapshots, and restores run in background workers; restart-safe with up to 3 retry attempts, state persisted in `job_store.json`
 - **Partial-failure reporting** — `add` and `upsert` with `report=true` return `{applied: N, failed: [...]}` instead of fail-fast
 
 ### Data-Plane Request Notes

--- a/server/README.md
+++ b/server/README.md
@@ -28,7 +28,7 @@ cargo build --release
 
 ### Health
 - `GET /healthz`
-- `GET /metrics` — Prometheus text metrics (no auth required)
+- `GET /metrics` — Prometheus text metrics (requires `Authorization: ApiKey <key>`)
 - `GET/POST /v1/tenants/:tenant/databases/:database/collections`
 - `DELETE /v1/tenants/:tenant/databases/:database/collections/:collection`
 - `POST /v1/tenants/:tenant/databases/:database/collections/:collection/add`


### PR DESCRIPTION
Full docs audit after v0.5.1. Fixes: README rerank f16->INT8, SERVER_API missing restore job_type, SERVER_DESIGN stale /search endpoint, COMPATIBILITY_MATRIX restore status, DEVELOPMENT.md dead sprint_process.md link, server/README missing restore/metrics/quota_usage.