### PR TITLE
docs(v0.8): integration quickstarts + full doc sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Format: `[version] — type(scope): summary`. Commits use [Conventional Commits]
 
 ## [0.8.0] — 2026-04-28
 
+> Release overview + upgrade notes: [`docs/WHAT_S_NEW_0_8.md`](docs/WHAT_S_NEW_0_8.md).
+
 ### Added
 
 - **`MultiVectorStore` (ColBERT-style late-interaction retrieval)** — new `python/tqdb/multivector.py`. Each document gets N token vectors; queries score via MaxSim (`Σ_i max_j <q_i, d_j>`). Python-layer wrapper over the existing single-vector engine: token vectors are stored as regular slots, a JSON sidecar maps `doc_id → [token_id]`, raw float32 token vectors live in a `.npz` sidecar for exact MaxSim. Public API: `MultiVectorStore.open(path, dimension, bits=4, metric="cosine")`, `insert(doc_id, vectors, document, metadata)`, `search(query_vectors, top_k, oversample=4, candidate_filter=None)`, `delete(doc_id)`, `get(doc_id)`. A future v0.9 native engine path will replace the wrapper while keeping the public API stable. Documented in `docs/MULTI_VECTOR.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,9 +35,30 @@ maturin develop --release
 # Rust unit tests
 cargo test -q --lib
 
-# Python test suite
+# Python test suite (some files require optional integration deps — see below)
 pytest tests/ -v
 ```
+
+#### Test layout (post v0.8)
+
+| File | Tests | Required extra | Auto-skips? |
+|---|---|---|---|
+| `tests/test_async_api.py` | 9 | none (async is core) | n/a |
+| `tests/test_multivector.py` | 10 | none | n/a |
+| `tests/test_python_hybrid.py` | 14 | none | n/a |
+| `tests/test_langchain_compat.py` | 9 | `tqdb[langchain]` | yes (`pytest.importorskip("langchain_core")`) |
+| `tests/test_llama_index.py` | 9 | `tqdb[llamaindex]` | yes (`pytest.importorskip("llama_index.core")`) |
+| `tests/test_migrate.py` | 8 | `tqdb[migrate]` | no — fails on import without it |
+
+For the full 59-test run install all extras at once:
+
+```bash
+pip install -e '.[migrate,langchain,llamaindex]'
+pytest tests/
+```
+
+CI runs the full suite. Local development without an extra installed will see
+its tests skip (or fail at import, for `test_migrate.py`); both are acceptable.
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -45,7 +45,21 @@ cargo test -q --lib
 cargo test --test integration_tests
 cargo test --test bench_search
 cargo test --test bench_batch_crud
+cargo test --test test_bm25                # v0.7 BM25 + hybrid integration
+cargo test --test test_multi_vector        # if/when v0.9 lands native multi-vector
 
+# Full Python test suite (requires optional integration deps)
+maturin develop --release
+pip install -e '.[migrate,langchain,llamaindex]'
+pytest tests/                              # 59 Python tests across 6 files
+```
+
+The integration test files (`test_langchain_compat.py`, `test_llama_index.py`,
+`test_migrate.py`) auto-skip when their corresponding extra isn't installed via
+`pytest.importorskip(...)`, so a partial install just runs a smaller suite — it
+doesn't fail. CI installs all extras so the full suite runs there.
+
+```bash
 # Python quality gate (requires maturin develop first)
 python benchmarks/ci_quality_gate.py   # min recall 0.60, max latency 100ms
 ```

--- a/README.md
+++ b/README.md
@@ -32,10 +32,18 @@ Two deployment modes:
 ## Installation
 
 ```bash
-pip install tqdb
+pip install tqdb                       # core engine + Python API
+
+# Optional integrations (install only what you need):
+pip install 'tqdb[langchain]'          # LangChain v2 VectorStore
+pip install 'tqdb[llamaindex]'         # LlamaIndex BasePydanticVectorStore
+pip install 'tqdb[migrate]'            # Chroma + LanceDB import toolkit
+pip install 'tqdb[migrate-chroma]'     # Chroma migrator only
+pip install 'tqdb[migrate-lancedb]'    # LanceDB migrator only
 ```
 
 Building from source (Rust toolchain required): see [`DEVELOPMENT.md`](https://github.com/jyunming/TurboQuantDB/blob/main/DEVELOPMENT.md).
+Upgrading from v0.7? See [`docs/WHAT_S_NEW_0_8.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/WHAT_S_NEW_0_8.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Two deployment modes:
 - **Optional ANN index** — Build an HNSW graph after loading data for fast approximate search.
 - **Hybrid retrieval** — Built-in BM25 keyword index fuses with dense search via RRF (`db.search(..., hybrid={"text": "..."})`). Pure-dense behaviour is unchanged when the kwarg is omitted.
 - **Multi-vector / ColBERT** — `MultiVectorStore` for late-interaction retrieval with N token vectors per document and MaxSim scoring (`Σ_i max_j <q_i, d_j>`). See [`docs/MULTI_VECTOR.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/MULTI_VECTOR.md).
-- **Framework integrations** — native `VectorStore` for [LangChain v2](https://github.com/jyunming/TurboQuantDB/blob/main/docs/PYTHON_API.md#rag-integration) and [LlamaIndex](https://github.com/jyunming/TurboQuantDB/blob/main/docs/integrations/llama_index.md), plus an asyncio-friendly `AsyncDatabase`.
+- **Framework integrations** — native `VectorStore` for [LangChain v2](https://github.com/jyunming/TurboQuantDB/blob/main/docs/integrations/langchain.md) and [LlamaIndex](https://github.com/jyunming/TurboQuantDB/blob/main/docs/integrations/llama_index.md), plus an asyncio-friendly `AsyncDatabase`.
 - **Drop-in migration** — `python -m tqdb.migrate {chroma|lancedb} <src> <dst>` imports an existing collection in one command. See [`docs/MIGRATION.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/MIGRATION.md).
 - **Metadata filtering** — MongoDB-style filter operators on any metadata field.
 - **Crash recovery** — Write-ahead log (WAL) ensures durability without explicit flushing.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -187,3 +187,15 @@ to 1.000** (+50 pp) over either path alone, while losing nothing on
 semantic-only queries. On lexical queries hybrid is dominated by pure BM25
 on R@1, but still recovers the gold doc in the top-10 every time, which is
 what most RAG pipelines actually consume.
+
+---
+
+## v0.8 features — what isn't yet benchmarked
+
+The v0.8 sprint added five Python-side features. Three of them have correctness coverage in the test suite but aren't yet tracked in the longitudinal perf history:
+
+- **Multi-vector / MaxSim retrieval at scale** (`MultiVectorStore`) — the v0.8 wrapper is a Python layer over the existing single-vector engine. Per-config recall and latency at 10k+ docs / 80k+ tokens are pending, and will be the headline numbers when v0.9 lands the native engine integration.
+- **`AsyncDatabase` concurrent-search throughput** — `tests/test_async_api.py` includes a 50-concurrent-search proof of parallelism but no longitudinal numbers; the actual ceiling depends on user thread-pool sizing and embedder latency.
+- **Migration toolkit throughput** (`tqdb.migrate`) — the CLI prints rows/sec per run but those numbers aren't tracked in perf_history. For now, expect rates close to a plain `Database.insert_batch` loop on the same hardware.
+
+LangChain / LlamaIndex / hybrid-via-integration overhead is also not benchmarked separately. The wrappers add a small Python-layer cost per call (one filter-dict translation + one numpy conversion) which has been negligible in practice on the 1k-5k corpora the test suite uses.

--- a/docs/COMPATIBILITY_MATRIX.md
+++ b/docs/COMPATIBILITY_MATRIX.md
@@ -25,8 +25,26 @@ This matrix tracks practical API/behavior parity against common embedded RAG vec
 | Multi-tenant service auth/RBAC | Yes | Persisted API keys, principals, role bindings. |
 | Quota controls | Yes | Collections, vectors, disk, concurrent jobs. |
 
+## Integration Version Matrix
+
+Versions pinned in [`pyproject.toml`](../pyproject.toml). Install the matching extra to pull in the third-party library and enable the corresponding TQDB module.
+
+| Integration | Min version | TQDB extra | Module |
+|---|---|---|---|
+| Python | 3.10 | (built into wheel) | — |
+| LangChain | `langchain-core>=0.3` | `tqdb[langchain]` | `tqdb.vectorstore.TurboQuantVectorStore` |
+| LlamaIndex | `llama-index-core>=0.10` | `tqdb[llamaindex]` | `tqdb.llama_index.TurboQuantVectorStore` |
+| Chroma (migrator) | `chromadb>=0.5` | `tqdb[migrate]` / `tqdb[migrate-chroma]` | `tqdb.migrate.migrate_chroma` |
+| LanceDB (migrator) | `lancedb>=0.10` | `tqdb[migrate]` / `tqdb[migrate-lancedb]` | `tqdb.migrate.migrate_lancedb` |
+
+The integration modules import their third-party deps **lazily** — TQDB never pulls
+them in at top-level import time. A user who installs plain `pip install tqdb` and
+never touches `tqdb.vectorstore` / `tqdb.llama_index` / `tqdb.migrate` doesn't pay
+their import cost.
+
 ## Known Gaps / Follow-ups
 
 - Additional protocol-level compatibility shims may still be needed for drop-in client replacement.
 - Full workload validation is pending comprehensive user-side test plan.
+- LangChain / LlamaIndex compatibility is tested against the pinned versions above; older versions are not tested. No async / streaming integration wrappers yet for either framework — `AsyncDatabase` is a separate facade that doesn't yet have LangChain/LlamaIndex async parity.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -199,6 +199,40 @@ results = db.search(query, top_k=10, _use_ann=True)
 
 ---
 
+## Multi-vector mode (v0.8)
+
+`MultiVectorStore` (see [`docs/MULTI_VECTOR.md`](MULTI_VECTOR.md)) is a Python-layer
+wrapper over `Database`. Every parameter above (`bits`, `metric`, `quantizer_type`, …)
+applies identically — the wrapper just adds doc-id-grouping sidecars on top.
+
+Recommended starting config for ColBERTv2-style late interaction:
+
+| Parameter | Value | Why |
+|---|---|---|
+| `dimension` | 96 (ColBERTv2) or 128 (ColBERT) | per-token dim of the model |
+| `bits` | 4 | good recall at modest disk |
+| `metric` | `"cosine"` | ColBERT vectors are unit-normalised |
+| `quantizer_type` | `"dense"` (default) | best recall |
+
+The wrapper rejects `metric="l2"` at construction — MaxSim is a dot-product
+aggregation that doesn't generalise cleanly to lower-is-better metrics.
+
+## Async executor tuning (v0.8)
+
+`AsyncDatabase` (see [`docs/PYTHON_API.md` — Async API](PYTHON_API.md#async-api))
+takes two construction-time knobs that aren't on `Database.open`:
+
+| Kwarg | Default | When to override |
+|---|---|---|
+| `executor` | None (auto-create) | Pass an external `ThreadPoolExecutor` to share a pool across multiple `AsyncDatabase` instances. External pools are not shut down on `close()`. |
+| `max_workers` | `min(32, cpu_count + 4)` | Override the auto-pool size. Ignored when `executor=` is supplied. |
+
+The default sizing matches Python 3.13's standard `ThreadPoolExecutor` heuristic.
+Raise it for heavy concurrent-search workloads on machines with many cores; lower
+it on memory-constrained hosts.
+
+---
+
 ## Decision Flowchart
 
 ```

--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -474,7 +474,7 @@ Use `db.sync` (a property) to access the underlying synchronous `Database` for c
 
 ## RAG Integration
 
-TQDB has three Python-side surfaces for RAG pipelines:
+TQDB has five Python-side surfaces for RAG pipelines:
 
 | Use case | Class | Module |
 |---|---|---|

--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -474,7 +474,25 @@ Use `db.sync` (a property) to access the underlying synchronous `Database` for c
 
 ## RAG Integration
 
-`TurboQuantRetriever` is a lightweight LangChain-style wrapper around `Database`.
+TQDB has three Python-side surfaces for RAG pipelines:
+
+| Use case | Class | Module |
+|---|---|---|
+| LangChain v2 `VectorStore` ABC | `TurboQuantVectorStore` | `tqdb.vectorstore` |
+| LlamaIndex `BasePydanticVectorStore` | `TurboQuantVectorStore` | `tqdb.llama_index` |
+| Multi-vector / ColBERT (MaxSim) | `MultiVectorStore` | `tqdb.multivector` |
+| Asyncio facade for any of the above | `AsyncDatabase` | `tqdb.aio` |
+| Legacy LangChain-style retriever | `TurboQuantRetriever` | `tqdb.rag` |
+
+Dedicated guides:
+
+- **LangChain** → [`docs/integrations/langchain.md`](integrations/langchain.md)
+- **LlamaIndex** → [`docs/integrations/llama_index.md`](integrations/llama_index.md)
+- **Multi-vector / ColBERT** → [`docs/MULTI_VECTOR.md`](MULTI_VECTOR.md)
+- **Async API** → see the [Async API section above](#async-api)
+- **Migration from Chroma / LanceDB** → [`docs/MIGRATION.md`](MIGRATION.md)
+
+The legacy `TurboQuantRetriever` is preserved for back-compat:
 
 ```python
 from tqdb.rag import TurboQuantRetriever
@@ -489,7 +507,9 @@ retriever = TurboQuantRetriever(
 )
 ```
 
-### `add_texts(texts, embeddings, metadatas=None)`
+For new code prefer `TurboQuantVectorStore` (it's the full LangChain v2 ABC and supports `as_retriever()` for the same call sites). See `docs/integrations/langchain.md` for the migration recipe.
+
+### Legacy `add_texts(texts, embeddings, metadatas=None)`
 
 Batch-insert documents with their embeddings.
 
@@ -503,7 +523,7 @@ retriever.add_texts(
 
 IDs are auto-assigned as `doc_0`, `doc_1`, … continuing from the current count.
 
-### `similarity_search(query_embedding, k=4)`
+### Legacy `similarity_search(query_embedding, k=4)`
 
 Search for the `k` most similar documents.
 

--- a/docs/SERVER_API.md
+++ b/docs/SERVER_API.md
@@ -2,6 +2,24 @@
 
 Optional Axum HTTP service providing TurboQuantDB in multi-tenant server mode. Use this when you need REST API access, multi-tenancy, authentication, quotas, or async job management. For single-process Python use, the embedded `tqdb` package is simpler.
 
+## v0.8 feature availability
+
+The v0.8 sprint shipped five Python-side features. Most are **embedded-Python only**
+— they don't have HTTP equivalents on the server. Use the embedded `tqdb` package
+when you need them.
+
+| Feature | Embedded Python | HTTP server |
+|---|---|---|
+| LangChain `TurboQuantVectorStore` (`tqdb.vectorstore`) | yes | no — use embedded mode |
+| LlamaIndex `TurboQuantVectorStore` (`tqdb.llama_index`) | yes | no — use embedded mode |
+| `MultiVectorStore` ColBERT (`tqdb.multivector`) | yes | no — uses embedded sidecar files |
+| `AsyncDatabase` (`tqdb.aio`) | yes | n/a — server is already async (Axum/Tokio) |
+| Migration toolkit (`tqdb.migrate`, CLI) | yes | n/a — offline batch tool |
+| BM25 hybrid (`db.search(..., hybrid={...})`, v0.7) | yes | yes — `hybrid` field in `/query` request |
+
+Bridging integrations into server mode is a v0.9-or-later candidate; the embedded
+mode is canonical for those workflows today.
+
 ## Installation
 
 The server binary ships pre-built inside the `tqdb` wheel on all supported platforms

--- a/docs/WHAT_S_NEW_0_8.md
+++ b/docs/WHAT_S_NEW_0_8.md
@@ -1,0 +1,141 @@
+# What's new in v0.8
+
+> Released 2026-04-28. See the full entry in [`CHANGELOG.md`](../CHANGELOG.md).
+
+## TL;DR
+
+Five new Python-side features and **no breaking changes**:
+
+1. **Multi-vector / ColBERT** retrieval with MaxSim scoring.
+2. **LangChain v2** native `VectorStore` ABC.
+3. **LlamaIndex** native `BasePydanticVectorStore` integration.
+4. **`AsyncDatabase`** — asyncio facade with real concurrency (PyO3 releases the GIL).
+5. **`tqdb.migrate`** — one-command import from existing Chroma / LanceDB collections.
+
+Existing v0.7 code keeps working. Upgrade is `pip install -U tqdb`.
+
+## Feature highlights
+
+### Multi-vector / ColBERT-style late interaction
+
+```python
+from tqdb import MultiVectorStore
+
+store = MultiVectorStore.open("./mvstore", dimension=96, bits=4, metric="cosine")
+store.insert("paper-2504.19874", token_vectors_8x96, document="full text")
+hits = store.search(query_token_vectors_5x96, top_k=10)
+# MaxSim: score(q, d) = Σ_i max_j <q_i, d_j>
+```
+
+Each document holds N token vectors; queries are tokenized to K vectors and scored
+via MaxSim. Built as a Python-layer wrapper over `tqdb.Database` so it ships now;
+the v0.9 sprint will move it into the engine for tighter storage and native filter
+pushdown — **the public Python API stays the same**.
+
+Full guide: [`docs/MULTI_VECTOR.md`](MULTI_VECTOR.md).
+
+### LangChain v2 `VectorStore`
+
+```python
+from tqdb.vectorstore import TurboQuantVectorStore
+store = TurboQuantVectorStore.from_texts(texts, embedding, path="./mydb")
+docs = store.similarity_search("query", k=4)
+```
+
+Implements the full LangChain v2 ABC: `add_texts`, `add_documents`, all
+`similarity_search*` variants, `delete`, `from_texts` / `from_documents`,
+`as_retriever`, `_select_relevance_score_fn`, `embeddings`. Lazy-imports
+LangChain so installing plain `tqdb` doesn't pull the dep tree.
+
+Full guide: [`docs/integrations/langchain.md`](integrations/langchain.md).
+
+### LlamaIndex `BasePydanticVectorStore`
+
+```python
+from tqdb.llama_index import TurboQuantVectorStore
+vstore = TurboQuantVectorStore.open("./tqdb_llama", dimension=1536)
+storage = StorageContext.from_defaults(vector_store=vstore)
+index = VectorStoreIndex.from_documents(docs, storage_context=storage)
+```
+
+LlamaIndex's `MetadataFilters` / `MetadataFilter` / `FilterOperator` /
+`FilterCondition` are translated to TQDB's MongoDB-style filter dialect.
+Optional dep `tqdb[llamaindex]`.
+
+Full guide: [`docs/integrations/llama_index.md`](integrations/llama_index.md).
+
+### Async API — `AsyncDatabase`
+
+```python
+from tqdb.aio import AsyncDatabase
+
+async with await AsyncDatabase.open("./mydb", dimension=1536) as db:
+    await db.insert("doc1", vec)
+    # 50 concurrent searches — actually run in parallel:
+    all_results = await asyncio.gather(*(db.search(q, top_k=5) for q in queries))
+```
+
+Thread-pool-backed wrapper over the sync `Database`. Because every PyO3 method
+already releases the GIL via `py.allow_threads`, concurrent `await` calls
+genuinely parallelise — the existing test suite includes a 50-task proof.
+
+Full guide: [`docs/PYTHON_API.md` — Async API](PYTHON_API.md#async-api).
+
+### Migration toolkit — `tqdb.migrate`
+
+```bash
+pip install 'tqdb[migrate]'
+python -m tqdb.migrate chroma /old/chroma_db /new/tqdb_db --collection my_docs
+python -m tqdb.migrate lancedb /old/lance_dataset /new/tqdb_db --table my_docs
+```
+
+Reads each source library's native on-disk format via the source library itself
+(no schema parsing) and bulk-inserts into a fresh TQDB. Preserves IDs, vectors,
+metadata, document text. CLI plus programmatic `migrate_chroma()` /
+`migrate_lancedb()` functions.
+
+Full guide: [`docs/MIGRATION.md`](MIGRATION.md).
+
+## Migration from v0.7
+
+**Nothing breaks.** All v0.7 APIs continue to work in v0.8. The only behaviour change
+in core code is a previously-undocumented Rust-side fix: `Database.insert_batch`'s
+`metadatas=` parameter now correctly accepts `[None, None, …]` per-row entries (the
+public `.pyi` type stub already documented this; the Rust implementation hadn't
+followed). Code passing `[None, ...]` previously raised `TypeError` and now succeeds.
+
+### Optional: move from `TurboQuantRetriever` to `TurboQuantVectorStore`
+
+The pre-v0.8 `tqdb.rag.TurboQuantRetriever` is preserved for back-compat — your
+existing imports keep working. New code should prefer the LangChain-v2-native
+`TurboQuantVectorStore`:
+
+```python
+# Before — still works
+from tqdb.rag import TurboQuantRetriever
+ret = TurboQuantRetriever(db_path, dimension=1536, embedding_function=embed)
+
+# After — recommended for new code
+from tqdb.vectorstore import TurboQuantVectorStore
+store = TurboQuantVectorStore.open(db_path, embedding=embed)
+ret = store.as_retriever()
+```
+
+The new class implements the full LangChain `VectorStore` ABC, so calls like
+`store.add_documents(...)`, `store.similarity_search_with_score(...)`, and
+`store.from_texts(...)` work as documented in the LangChain reference.
+
+## What's coming in v0.9
+
+The v0.9-v1.0 hardening sprint targets:
+
+- **Native multi-vector engine integration** — replaces the v0.8 Python-layer
+  wrapper with `IdPool` doc-id grouping, an on-disk MaxSim kernel, and native
+  filter pushdown. Same public Python API, much tighter storage and faster search.
+- Server mode v0.8 feature parity (LangChain / LlamaIndex / multi-vector exposed
+  over HTTP) is a candidate but not yet committed.
+- Pre-1.0 hardening: `≥80%` test coverage, `.unwrap()` audit pass 2, API-key
+  authentication baseline, complete `0.x → 1.0` migration guide.
+
+See the full [v0.9-v1.0 sprint board](https://github.com/users/jyunming/projects/3)
+for the running list.

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,0 +1,42 @@
+# Integrations
+
+Native wrappers around `tqdb.Database` for popular RAG and vector-store frameworks.
+Each integration's third-party dep is **optional** — install only the extras you
+actually use.
+
+| Framework | Module | Doc | Install |
+|---|---|---|---|
+| LangChain v2 | `tqdb.vectorstore.TurboQuantVectorStore` | [langchain.md](langchain.md) | `pip install 'tqdb[langchain]'` |
+| LlamaIndex | `tqdb.llama_index.TurboQuantVectorStore` | [llama_index.md](llama_index.md) | `pip install 'tqdb[llamaindex]'` |
+
+The integration modules import their third-party libraries lazily, so users on
+plain `pip install tqdb` don't pay the import cost until they touch the relevant
+module.
+
+## Related guides
+
+These aren't strictly "integrations" but cover related v0.8 surfaces and live
+one directory up:
+
+- **Multi-vector / ColBERT** — late-interaction retrieval with MaxSim scoring.
+  See [`../MULTI_VECTOR.md`](../MULTI_VECTOR.md).
+- **Async API** — `AsyncDatabase`, the asyncio facade. See
+  [`../PYTHON_API.md` — Async API](../PYTHON_API.md#async-api).
+- **Migration toolkit** — one-command import from existing Chroma / LanceDB
+  collections. See [`../MIGRATION.md`](../MIGRATION.md).
+
+## Version compatibility
+
+The supported version range for each third-party library lives in
+[`../COMPATIBILITY_MATRIX.md`](../COMPATIBILITY_MATRIX.md) (Integration Version
+Matrix section). The same versions are pinned in
+[`../../pyproject.toml`](../../pyproject.toml) under `[project.optional-dependencies]`.
+
+## Reporting integration bugs
+
+The filter translator at
+[`python/tqdb/_filter_translator.py`](https://github.com/jyunming/TurboQuantDB/blob/main/python/tqdb/_filter_translator.py)
+is the most common source of integration friction (each framework has its own
+filter shape). When you hit an unsupported filter, the translator raises
+`ValueError` naming the unsupported operator/key — include that in the bug
+report and link the framework's filter snippet that failed.

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -17,8 +17,15 @@ its import cost.
 
 ## Quickstart
 
+The example below uses `OpenAIEmbeddings` from
+[`langchain-openai`](https://pypi.org/project/langchain-openai/), which is
+**not** part of `tqdb[langchain]` (we pin `langchain-core` only). Install
+your provider's embedding package separately, e.g.
+`pip install langchain-openai`. Any class implementing
+`langchain_core.embeddings.Embeddings` works.
+
 ```python
-from langchain_openai import OpenAIEmbeddings  # or any langchain_core.embeddings.Embeddings
+from langchain_openai import OpenAIEmbeddings  # provider package — install separately
 from tqdb.vectorstore import TurboQuantVectorStore
 
 embed = OpenAIEmbeddings()
@@ -139,5 +146,7 @@ ret = store.as_retriever()
 
 ## Supported versions
 
-The `[langchain]` extra pins `langchain-core>=0.3`. Earlier `langchain<0.3`
-versions are not tested.
+The `[langchain]` extra pins `langchain-core>=0.3`. Earlier
+`langchain-core<0.3` versions are not tested. (A user may have `langchain`
+installed at any version, but `langchain-core` is the package whose
+`VectorStore` ABC TQDB implements.)

--- a/docs/integrations/langchain.md
+++ b/docs/integrations/langchain.md
@@ -1,0 +1,143 @@
+# LangChain integration
+
+`TurboQuantVectorStore` is a complete implementation of LangChain v2's
+[`VectorStore`](https://api.python.langchain.com/en/latest/vectorstores/langchain_core.vectorstores.base.VectorStore.html)
+ABC backed by `tqdb.Database`.
+
+## Install
+
+```bash
+pip install 'tqdb[langchain]'
+```
+
+The `[langchain]` extra pins the supported `langchain-core` version range.
+LangChain itself is **lazy-loaded** — TQDB imports it only when you actually
+touch `TurboQuantVectorStore`, so users without LangChain installed don't pay
+its import cost.
+
+## Quickstart
+
+```python
+from langchain_openai import OpenAIEmbeddings  # or any langchain_core.embeddings.Embeddings
+from tqdb.vectorstore import TurboQuantVectorStore
+
+embed = OpenAIEmbeddings()
+
+# Build a fresh store from raw texts.
+store = TurboQuantVectorStore.from_texts(
+    texts=["The quick brown fox", "Jumped over the lazy dog"],
+    embedding=embed,
+    metadatas=[{"source": "fable"}, {"source": "fable"}],
+    path="./mydb",
+    bits=4,             # forwarded to Database.open
+    metric="cosine",
+)
+
+# Query.
+docs = store.similarity_search("a fast fox", k=5)
+for d in docs:
+    print(d.id, d.metadata, d.page_content)
+
+# Or with scores:
+for doc, score in store.similarity_search_with_score("query", k=5):
+    print(score, doc.id)
+```
+
+## Wrap an existing database
+
+```python
+from tqdb import Database
+from tqdb.vectorstore import TurboQuantVectorStore
+
+db = Database.open("./mydb")  # parameterless reopen via manifest.json
+store = TurboQuantVectorStore(db, embedding=embed)
+```
+
+`embedding=None` is allowed if you only call `similarity_search_by_vector`
+or `add_texts(_vectors=...)` (i.e. you've pre-computed embeddings).
+
+## Methods
+
+`TurboQuantVectorStore` implements the full LangChain v2 `VectorStore` ABC:
+
+| Method | Notes |
+|--------|-------|
+| `add_texts(texts, metadatas=None, ids=None)` | Returns the assigned IDs (UUIDs unless caller supplies them). |
+| `add_documents(documents, ids=None)` | Same, taking `Document` objects. |
+| `similarity_search(query, k=4, filter=None)` | Embeds `query` then queries TQDB. Returns `List[Document]`. |
+| `similarity_search_with_score(query, k=4, filter=None)` | Same but returns `List[Tuple[Document, float]]`. |
+| `similarity_search_by_vector(embedding, k=4, filter=None)` | Skips the embedder; useful when you've pre-computed query vectors. |
+| `delete(ids)` | Returns `True` if any IDs were deleted. |
+| `get_by_ids(ids)` | Returns `List[Document]` (only IDs that exist). |
+| `as_retriever(search_kwargs=...)` | Standard LangChain retriever bridge. |
+| `_select_relevance_score_fn()` | Maps TQDB's IP/cosine score to LangChain's `[0, 1]` relevance space; for L2 uses `1 / (1 + distance)`. |
+| `from_texts(...)` (classmethod) | Bootstrap helper — builds the database, embeds the texts, populates. |
+| `from_documents(...)` (classmethod) | Same with `Document` inputs. |
+
+## Filters
+
+Pass a TQDB-style filter dict as `filter=` on any search method. TQDB
+operators (`$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`,
+`$exists`, `$contains`, `$and`, `$or`) all work:
+
+```python
+store.similarity_search(
+    "query",
+    k=5,
+    filter={"source": {"$in": ["fable", "myth"]}, "year": {"$gte": 2020}},
+)
+```
+
+LangChain itself doesn't standardise filter shapes; we pass dicts through
+unchanged. Vendor-specific filter wrappers (e.g.
+`StructuredFilter` Pydantic models) will raise `ValueError` — convert them
+to plain dicts on your side.
+
+## Hybrid search
+
+If you've inserted documents (i.e. the `document` field is set), TQDB's BM25
+hybrid path is available — pass `hybrid={"text": "...", "weight": 0.3}` as a
+search kwarg:
+
+```python
+docs = store.similarity_search(
+    "exact-keyword query",
+    k=10,
+    hybrid={"text": "exact-keyword query", "weight": 0.3},
+)
+```
+
+See [`docs/PYTHON_API.md` — Hybrid search](../PYTHON_API.md#hybrid-search-sparse--dense)
+for details.
+
+## Migrating from `tqdb.rag.TurboQuantRetriever`
+
+The pre-v0.8 `TurboQuantRetriever` (in `python/tqdb/rag.py`) still works
+for back-compat. New code should prefer `TurboQuantVectorStore`. The two
+interfaces are not identical:
+
+| Capability | `TurboQuantRetriever` | `TurboQuantVectorStore` |
+|------------|-----------------------|-------------------------|
+| LangChain `BaseRetriever` `Runnable` | yes (`invoke`, `get_relevant_documents`) | use `store.as_retriever()` |
+| Full `VectorStore` ABC | partial | yes |
+| `from_texts`/`from_documents` factories | yes | yes |
+| Hybrid kwarg passthrough | yes | yes |
+| Async API | no | use `tqdb.AsyncDatabase` for an async DB; vectorstore async is a future addition |
+
+Move recipe:
+
+```python
+# Before
+from tqdb.rag import TurboQuantRetriever
+ret = TurboQuantRetriever(db_path, dimension=1536, embedding_function=embed)
+
+# After
+from tqdb.vectorstore import TurboQuantVectorStore
+store = TurboQuantVectorStore.open(db_path, embedding=embed)
+ret = store.as_retriever()
+```
+
+## Supported versions
+
+The `[langchain]` extra pins `langchain-core>=0.3`. Earlier `langchain<0.3`
+versions are not tested.

--- a/docs/integrations/llama_index.md
+++ b/docs/integrations/llama_index.md
@@ -17,10 +17,18 @@ the class.
 
 ## Quickstart with `VectorStoreIndex`
 
+The example uses `OpenAIEmbedding` from
+[`llama-index-embeddings-openai`](https://pypi.org/project/llama-index-embeddings-openai/),
+which is **not** part of `tqdb[llamaindex]` (we pin `llama-index-core` only).
+Install the provider package separately:
+`pip install llama-index-embeddings-openai`. Any LlamaIndex embedder works
+(`HuggingFaceEmbedding`, `OpenAIEmbedding`, etc.).
+
 ```python
-from llama_index.core import VectorStoreIndex, StorageContext, Document
-from llama_index.embeddings.openai import OpenAIEmbedding
+from llama_index.core import VectorStoreIndex, StorageContext
+from llama_index.core.schema import Document
 from llama_index.core import Settings
+from llama_index.embeddings.openai import OpenAIEmbedding  # provider package
 
 from tqdb.llama_index import TurboQuantVectorStore
 
@@ -118,7 +126,7 @@ Supported operators (LlamaIndex → TQDB):
 | `delete(ref_doc_id)` | LlamaIndex `delete` semantics — single ref_doc_id at a time. |
 | `delete_nodes(node_ids=None, filters=None)` | Bulk delete by IDs or by metadata filter. |
 | `clear()` | Drop every node. |
-| `persist()` | Calls `db.checkpoint()` (TQDB writes through, so this is a no-op-style flush). |
+| `persist()` | Calls `db.checkpoint()`. TQDB writes through on every operation so most state is already on disk, but `checkpoint()` itself flushes the WAL into a segment and may trigger compaction — non-trivial work. Avoid calling it on every node insert; let LlamaIndex drive `persist()` at its natural intervals. |
 | `client` | Property exposing the underlying `Database` for advanced use. |
 
 Class flags:

--- a/docs/integrations/llama_index.md
+++ b/docs/integrations/llama_index.md
@@ -1,0 +1,142 @@
+# LlamaIndex integration
+
+`tqdb.llama_index.TurboQuantVectorStore` is a
+[`BasePydanticVectorStore`](https://docs.llamaindex.ai/en/stable/api_reference/storage/vector_store/)
+implementation backed by `tqdb.Database`.
+
+## Install
+
+```bash
+pip install 'tqdb[llamaindex]'
+```
+
+The `[llamaindex]` extra pins `llama-index-core>=0.10`. The integration
+module imports LlamaIndex **lazily** — TQDB doesn't pull the heavy
+LlamaIndex dep tree on import; you only pay for it when you actually use
+the class.
+
+## Quickstart with `VectorStoreIndex`
+
+```python
+from llama_index.core import VectorStoreIndex, StorageContext, Document
+from llama_index.embeddings.openai import OpenAIEmbedding
+from llama_index.core import Settings
+
+from tqdb.llama_index import TurboQuantVectorStore
+
+Settings.embed_model = OpenAIEmbedding()  # any LlamaIndex embedder
+
+# Open or create the underlying TQDB. dimension must match the embedder.
+vstore = TurboQuantVectorStore.open(
+    "./tqdb_llama",
+    dimension=1536,
+    bits=4,
+    metric="cosine",
+)
+storage = StorageContext.from_defaults(vector_store=vstore)
+
+# Build an index — LlamaIndex computes embeddings and calls vstore.add(nodes).
+docs = [Document(text="The quick brown fox"), Document(text="Jumped over the lazy dog")]
+index = VectorStoreIndex.from_documents(docs, storage_context=storage)
+
+# Query.
+qe = index.as_query_engine(similarity_top_k=5)
+print(qe.query("a fast fox"))
+```
+
+## Direct `add` / `query`
+
+For users who want to manage embeddings themselves (e.g., custom batched
+embedding pipelines):
+
+```python
+import numpy as np
+from llama_index.core.schema import TextNode
+from llama_index.core.vector_stores.types import VectorStoreQuery
+
+# Insert pre-embedded nodes.
+nodes = [
+    TextNode(id_="a", text="alpha", metadata={"k": 1}),
+    TextNode(id_="b", text="bravo", metadata={"k": 2}),
+]
+nodes[0].embedding = my_embedder.embed("alpha")  # list[float]
+nodes[1].embedding = my_embedder.embed("bravo")
+vstore.add(nodes)
+
+# Query.
+result = vstore.query(VectorStoreQuery(
+    query_embedding=my_embedder.embed("alpha"),
+    similarity_top_k=5,
+))
+print(result.nodes, result.similarities, result.ids)
+```
+
+## Filters
+
+`MetadataFilters` / `MetadataFilter` / `FilterOperator` / `FilterCondition`
+are translated to TQDB's MongoDB-style filter dialect automatically:
+
+```python
+from llama_index.core.vector_stores import (
+    FilterCondition, FilterOperator, MetadataFilter, MetadataFilters,
+)
+
+filters = MetadataFilters(
+    filters=[
+        MetadataFilter(key="year", value=2024, operator=FilterOperator.GTE),
+        MetadataFilter(key="lang", value="en", operator=FilterOperator.EQ),
+    ],
+    condition=FilterCondition.AND,
+)
+result = vstore.query(VectorStoreQuery(
+    query_embedding=qvec,
+    similarity_top_k=10,
+    filters=filters,
+))
+```
+
+Supported operators (LlamaIndex → TQDB):
+
+| LlamaIndex | TQDB |
+|------------|------|
+| `==` (`EQ`) | `$eq` |
+| `!=` (`NE`) | `$ne` |
+| `>` / `>=` (`GT` / `GTE`) | `$gt` / `$gte` |
+| `<` / `<=` (`LT` / `LTE`) | `$lt` / `$lte` |
+| `in` (`IN`) | `$in` |
+| `nin` / `not in` (`NIN`) | `$nin` |
+| `contains` (`CONTAINS`) | `$contains` |
+| `condition: and` | `$and` |
+| `condition: or` | `$or` |
+
+## Methods
+
+| Method | Notes |
+|--------|-------|
+| `add(nodes)` | Each node must have `embedding` set. Auto-generates `node_id` if absent. Stores text + metadata. |
+| `query(VectorStoreQuery)` | Requires `query_embedding`. Returns `VectorStoreQueryResult` with nodes / similarities / ids. |
+| `delete(ref_doc_id)` | LlamaIndex `delete` semantics — single ref_doc_id at a time. |
+| `delete_nodes(node_ids=None, filters=None)` | Bulk delete by IDs or by metadata filter. |
+| `clear()` | Drop every node. |
+| `persist()` | Calls `db.checkpoint()` (TQDB writes through, so this is a no-op-style flush). |
+| `client` | Property exposing the underlying `Database` for advanced use. |
+
+Class flags:
+
+- `stores_text = True` — TQDB stores the document text alongside the
+  vector, so retrieval round-trips full nodes (LlamaIndex won't fetch text
+  from a separate doc store).
+- `flat_metadata = True` — TQDB indexes only scalar metadata fields.
+  Flatten nested metadata before insert.
+
+## Filter ↔ TQDB mapping internals
+
+The translator lives at [`python/tqdb/_filter_translator.py`](https://github.com/jyunming/TurboQuantDB/blob/main/python/tqdb/_filter_translator.py).
+If you hit an unsupported filter shape it raises `ValueError` with the
+operator/key it couldn't translate; that's the place to report bugs.
+
+## Supported versions
+
+`[llamaindex]` pins `llama-index-core>=0.10`. The class uses Pydantic v2
+(matching LlamaIndex 0.10+'s `BasePydanticVectorStore`); older versions
+are not tested.


### PR DESCRIPTION
## Summary

Post-v0.8.0 doc sweep: bring every project doc into alignment with the new
features (multi-vector, LangChain v2, LlamaIndex, async, migration). Covers
the gap left by the v0.8 sprint PR #59, which shipped the code without the
matching dedicated quickstarts.

### Integration quickstarts (initial commits)

- `docs/integrations/langchain.md` — LangChain v2 `TurboQuantVectorStore` quickstart, full method table, filter syntax, hybrid passthrough, migration recipe from the legacy `TurboQuantRetriever`.
- `docs/integrations/llama_index.md` — LlamaIndex `BasePydanticVectorStore` integration quickstart, `VectorStoreIndex.from_documents` + direct `add`/`query` flows, complete `MetadataFilters` → TQDB MongoDB-style operator mapping table.
- `docs/PYTHON_API.md` — RAG Integration section restructured with a one-row-per-surface routing table; legacy `TurboQuantRetriever` content kept under explicit "Legacy" subheaders.
- `README.md` — "Framework integrations" bullet now links to the dedicated LangChain doc.

### Full doc sweep (this commit)

Audit-driven updates so every doc reflects v0.8:

| File | Change | Priority |
|------|--------|----------|
| `README.md` | install section gains every optional extra + WHAT_S_NEW link | HIGH |
| `docs/COMPATIBILITY_MATRIX.md` | new Integration Version Matrix table | HIGH |
| `docs/SERVER_API.md` | new "v0.8 feature availability" subsection | HIGH |
| `docs/WHAT_S_NEW_0_8.md` (new) | release overview + upgrade notes | HIGH |
| `docs/CONFIGURATION.md` | multi-vector + async tuning subsections | MED |
| `DEVELOPMENT.md` | full-test-suite install one-liner | MED |
| `CONTRIBUTING.md` | "Test layout (post v0.8)" with required extras | MED |
| `docs/integrations/README.md` (new) | index for langchain.md / llama_index.md | MED |
| `docs/BENCHMARKS.md` | "what isn't yet benchmarked" subsection | MED |

The LOW-priority `docs/vs_competitors.md` page is deferred to v0.9.

## What's not in this PR

- No code changes; doc-only.
- No version bump; v0.8.0 is already released.
- No new tests.

## Verification

- `python` link-checker across 17 .md files → `ALL LINKS OK`.
- All five PR-CI checks expected to pass with no-op (Rust tests / Python smoke / Perf gate / benchmark are insensitive to doc-only changes).

