### PR TITLE
[codex] fix Python API compatibility audit bugs

### DIFF
--- a/python/tqdb/chroma_compat.py
+++ b/python/tqdb/chroma_compat.py
@@ -77,6 +77,26 @@ _VALID_GET_INCLUDE = {"ids", "metadatas", "documents", "embeddings"}
 _VALID_QUERY_INCLUDE = {"ids", "metadatas", "documents", "embeddings", "distances"}
 
 
+def _empty_get_response(include_set: set[str]) -> Dict[str, Any]:
+    return {
+        "ids": [],
+        "metadatas": [] if "metadatas" in include_set else None,
+        "documents": [] if "documents" in include_set else None,
+        "embeddings": [] if "embeddings" in include_set else None,
+    }
+
+
+def _empty_query_response(include_set: set[str], n_queries: int) -> Dict[str, Any]:
+    rows = [[] for _ in range(n_queries)]
+    return {
+        "ids": rows,
+        "distances": [[] for _ in range(n_queries)] if "distances" in include_set else None,
+        "metadatas": [[] for _ in range(n_queries)] if "metadatas" in include_set else None,
+        "documents": [[] for _ in range(n_queries)] if "documents" in include_set else None,
+        "embeddings": [[] for _ in range(n_queries)] if "embeddings" in include_set else None,
+    }
+
+
 def _apply_filter(records: List[Dict[str, Any]], where: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Very small subset of Chroma where-filter evaluation."""
     def _matches(metadata: Dict[str, Any], expr: Dict[str, Any]) -> bool:
@@ -429,6 +449,8 @@ class CompatCollection:
         where: Optional[Dict[str, Any]] = None,
     ) -> None:
         with self._write_lock:
+            if not os.path.exists(os.path.join(self._path, "manifest.json")):
+                return
             db = self._open_db(None)
             if ids and not where:
                 db.delete_batch(ids)
@@ -456,9 +478,9 @@ class CompatCollection:
             unknown = set(include) - _VALID_GET_INCLUDE
             if unknown:
                 raise ValueError(f"Unknown include fields: {unknown}. Valid: {_VALID_GET_INCLUDE}")
-        if not os.path.exists(os.path.join(self._path, "manifest.json")):
-            return {"ids": [], "metadatas": [], "documents": []}
         include_set = set(include or ["metadatas", "documents"])
+        if not os.path.exists(os.path.join(self._path, "manifest.json")):
+            return _empty_get_response(include_set)
         db = self._open_db(None)
 
         # BUG-C7: an explicitly-passed empty list means "return nothing";
@@ -510,6 +532,8 @@ class CompatCollection:
                 raise ValueError(f"Unknown include fields: {unknown}. Valid: {_VALID_QUERY_INCLUDE}")
         query_embeddings = self._embed(query_texts or [], query_embeddings)
         include_set = set(include or ["metadatas", "documents", "distances"])
+        if not os.path.exists(os.path.join(self._path, "manifest.json")):
+            return _empty_query_response(include_set, len(query_embeddings))
         db = self._open_db(None)
 
         all_ids, all_distances, all_metas, all_docs, all_embeddings = [], [], [], [], []

--- a/python/tqdb/lancedb_compat.py
+++ b/python/tqdb/lancedb_compat.py
@@ -84,7 +84,7 @@ _FIELD_NEQ_STR_PATTERN = re.compile(
     r"""^\s*(\w+)\s*!=\s*'([^']*)'\s*$"""
 )
 _FIELD_EQ_NUM_PATTERN = re.compile(
-    r"""^\s*(\w+)\s*=\s*(\d+(?:\.\d+)?)\s*$"""
+    r"""^\s*(\w+)\s*=\s*(-?\d+(?:\.\d+)?)\s*$"""
 )
 _FIELD_CMP_PATTERN = re.compile(
     r"""^\s*(\w+)\s*(>=|<=|>|<)\s*(-?\d+(?:\.\d+)?)\s*$"""
@@ -343,6 +343,8 @@ class CompatQuery:
         return self
 
     def to_list(self) -> List[Dict[str, Any]]:
+        if self._k == 0:
+            return []
         tqdb_filter: Optional[Dict[str, Any]] = None
         id_allowset: Optional[set] = None
         if self._where:
@@ -352,6 +354,9 @@ class CompatQuery:
                 id_allowset = set(id_cond["$in"])
             else:
                 tqdb_filter = parsed
+
+        if not os.path.exists(os.path.join(self._table._path, "manifest.json")):
+            return []
 
         # Full-table scan when query is None
         if self._query is None:

--- a/python/tqdb/multivector.py
+++ b/python/tqdb/multivector.py
@@ -289,6 +289,12 @@ class MultiVectorStore:
         n = vectors.shape[0]
         if n == 0:
             raise ValueError("must provide at least one token vector per doc")
+        expected_dim = self._db.stats().get("dimension")
+        if expected_dim is not None and vectors.shape[1] != expected_dim:
+            raise ValueError(
+                f"vector dimension mismatch: expected {expected_dim}, got "
+                f"{vectors.shape[1]}"
+            )
 
         # Replace semantics: drop stale token IDs first.
         old = self._index.remove(doc_id)

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 import pytest
@@ -110,44 +111,38 @@ async def test_get_and_metadata_update(tmp_db_path):
 
 @pytest.mark.asyncio
 async def test_concurrent_searches_dont_serialize(tmp_db_path):
-    """Fire 50 concurrent searches and confirm they don't run sequentially.
+    """Concurrent awaits should fan out through the executor.
 
-    The expected wall-clock is much less than (n_tasks × per-task latency);
-    if the wrapper accidentally serialized, total time would scale linearly
-    with task count.
+    Use a tiny blocking fake DB instead of timing real Rust searches. The real
+    search path can be sub-millisecond on small corpora, making ratio checks
+    mostly scheduler noise rather than a test of the Python wrapper.
     """
-    d = 64
-    async with await AsyncDatabase.open(tmp_db_path, dimension=d, bits=4) as db:
-        # Populate with enough data that each search isn't a sub-microsecond no-op.
-        ids = [f"d{i}" for i in range(2_000)]
-        vecs = np.stack([_vec(d, i) for i in range(2_000)])
-        await db.insert_batch(ids, vecs, None, None, "insert")
 
-        # Warm-up so the first call's overhead doesn't skew the median.
-        await db.search(_vec(d, 0), top_k=10)
+    class _SleepyDb:
+        def search(self, query, top_k):
+            time.sleep(0.02)
+            return [{"id": str(query), "score": 1.0}]
 
-        # Time a single search to set the bar.
+        def close(self):
+            return None
+
+    pool = ThreadPoolExecutor(max_workers=8)
+    db = AsyncDatabase(_SleepyDb(), executor=pool, owns_executor=True)
+    try:
+        n_tasks = 16
         t0 = time.perf_counter()
-        await db.search(_vec(d, 0), top_k=10)
-        single_s = max(time.perf_counter() - t0, 1e-4)
-
-        # Fire many concurrent searches.
-        n_tasks = 50
-        t0 = time.perf_counter()
-        await asyncio.gather(
-            *(db.search(_vec(d, i), top_k=10) for i in range(n_tasks))
+        results = await asyncio.gather(
+            *(db.search(i, top_k=1) for i in range(n_tasks))
         )
-        concurrent_s = time.perf_counter() - t0
+        elapsed = time.perf_counter() - t0
 
-        # Sequential would take ~ n_tasks × single_s. Concurrent should be
-        # WAY less — we accept up to a generous 0.5 × that as proof of
-        # parallelism (covers slow CI / Windows scheduler jitter).
-        sequential_estimate = n_tasks * single_s
-        assert concurrent_s < 0.5 * sequential_estimate, (
-            f"50 concurrent searches took {concurrent_s:.3f}s; sequential "
-            f"would be ~{sequential_estimate:.3f}s. The wrapper appears to "
-            f"serialize."
+        assert len(results) == n_tasks
+        assert elapsed < 0.20, (
+            f"{n_tasks} executor-backed searches took {elapsed:.3f}s; "
+            "the wrapper appears to serialize."
         )
+    finally:
+        await db.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_chroma_compat.py
+++ b/tests/test_chroma_compat.py
@@ -174,6 +174,17 @@ class TestGet:
         assert res["metadatas"] is not None
         assert res["documents"] is None
 
+    def test_get_empty_collection_honors_include_shape(self, tmp_path):
+        client = PersistentClient(str(tmp_path))
+        col = client.get_or_create_collection("col")
+        res = col.get(include=["embeddings"])
+        assert res == {
+            "ids": [],
+            "metadatas": None,
+            "documents": None,
+            "embeddings": [],
+        }
+
 
 # ---------------------------------------------------------------------------
 # query
@@ -220,6 +231,16 @@ class TestQuery:
         with pytest.raises(NotImplementedError):
             col.query(query_embeddings=[rand_vecs(1)[0]], where_document={"$contains": "hi"})
 
+    def test_query_empty_collection_returns_nested_empty_results(self, tmp_path):
+        client = PersistentClient(str(tmp_path))
+        col = client.get_or_create_collection("col")
+        res = col.query(query_embeddings=rand_vecs(2), n_results=3)
+        assert res["ids"] == [[], []]
+        assert res["distances"] == [[], []]
+        assert res["metadatas"] == [[], []]
+        assert res["documents"] == [[], []]
+        assert res["embeddings"] is None
+
 
 # ---------------------------------------------------------------------------
 # delete / upsert / update
@@ -245,6 +266,13 @@ class TestMutations:
         res = col.get()
         assert "a" not in res["ids"]
         assert "b" in res["ids"]
+
+    def test_delete_empty_collection_is_noop(self, tmp_path):
+        client = PersistentClient(str(tmp_path))
+        col = client.get_or_create_collection("col")
+        col.delete(ids=["missing"])
+        col.delete(where={"tag": {"$eq": "missing"}})
+        assert col.count() == 0
 
     def test_upsert_inserts_new(self, tmp_path):
         client = PersistentClient(str(tmp_path))

--- a/tests/test_chroma_compat_coverage.py
+++ b/tests/test_chroma_compat_coverage.py
@@ -610,12 +610,12 @@ class TestDeleteWithIdsAndWhere:
 
 
 # ===========================================================================
-# CompatCollection.get — line 296 (no manifest → early empty return)
+# CompatCollection.get — no manifest -> early empty return
 # ===========================================================================
 
 class TestGetNoManifest:
     def test_get_returns_empty_dict_when_no_manifest(self, tmp_path):
-        """Line 296: get() returns empty result dict when manifest.json absent."""
+        """get() returns an empty result dict when manifest.json is absent."""
         col = CompatCollection(str(tmp_path / "col"), "col", "ip")
         result = col.get()
         assert result == {
@@ -626,7 +626,7 @@ class TestGetNoManifest:
         }
 
     def test_get_with_ids_returns_empty_when_no_manifest(self, tmp_path):
-        """Line 296: get(ids=...) also returns empty when no manifest.json exists."""
+        """get(ids=...) also returns empty when manifest.json is absent."""
         col = CompatCollection(str(tmp_path / "col"), "col", "ip")
         result = col.get(ids=["a", "b"])
         assert result == {
@@ -637,7 +637,7 @@ class TestGetNoManifest:
         }
 
     def test_get_with_where_returns_empty_when_no_manifest(self, tmp_path):
-        """Line 296: get(where=...) also returns empty when no manifest.json."""
+        """get(where=...) also returns empty when manifest.json is absent."""
         col = CompatCollection(str(tmp_path / "col"), "col", "ip")
         result = col.get(where={"x": {"$eq": 1}})
         assert result == {

--- a/tests/test_chroma_compat_coverage.py
+++ b/tests/test_chroma_compat_coverage.py
@@ -618,19 +618,34 @@ class TestGetNoManifest:
         """Line 296: get() returns empty result dict when manifest.json absent."""
         col = CompatCollection(str(tmp_path / "col"), "col", "ip")
         result = col.get()
-        assert result == {"ids": [], "metadatas": [], "documents": []}
+        assert result == {
+            "ids": [],
+            "metadatas": [],
+            "documents": [],
+            "embeddings": None,
+        }
 
     def test_get_with_ids_returns_empty_when_no_manifest(self, tmp_path):
         """Line 296: get(ids=...) also returns empty when no manifest.json exists."""
         col = CompatCollection(str(tmp_path / "col"), "col", "ip")
         result = col.get(ids=["a", "b"])
-        assert result == {"ids": [], "metadatas": [], "documents": []}
+        assert result == {
+            "ids": [],
+            "metadatas": [],
+            "documents": [],
+            "embeddings": None,
+        }
 
     def test_get_with_where_returns_empty_when_no_manifest(self, tmp_path):
         """Line 296: get(where=...) also returns empty when no manifest.json."""
         col = CompatCollection(str(tmp_path / "col"), "col", "ip")
         result = col.get(where={"x": {"$eq": 1}})
-        assert result == {"ids": [], "metadatas": [], "documents": []}
+        assert result == {
+            "ids": [],
+            "metadatas": [],
+            "documents": [],
+            "embeddings": None,
+        }
 
 
 # ===========================================================================

--- a/tests/test_lancedb_compat.py
+++ b/tests/test_lancedb_compat.py
@@ -155,6 +155,19 @@ class TestSearch:
         arrow_tbl = tbl.search(q).limit(2).to_arrow()
         assert arrow_tbl.num_rows == 2
 
+    def test_limit_zero_returns_empty_for_vector_and_scan(self, tmp_path):
+        db = connect(str(tmp_path))
+        tbl = db.create_table("t", data=make_rows(2))
+        q = rand_vecs(1)[0].astype(np.float32)
+        assert tbl.search(q).limit(0).to_list() == []
+        assert tbl.search(None).limit(0).to_list() == []
+
+    def test_empty_table_search_returns_empty(self, tmp_path):
+        db = connect(str(tmp_path))
+        tbl = db.create_table("t")
+        assert tbl.search(None).limit(5).to_list() == []
+        assert tbl.search(rand_vecs(1)[0]).limit(5).to_list() == []
+
 
 # ---------------------------------------------------------------------------
 # where filter
@@ -281,6 +294,11 @@ class TestSQLParser:
         from tqdb.lancedb_compat import _parse_sql_where
         result = _parse_sql_where("count = 42")
         assert result == {"count": {"$eq": 42.0}}
+
+    def test_field_eq_negative_number(self):
+        from tqdb.lancedb_compat import _parse_sql_where
+        result = _parse_sql_where("score = -1")
+        assert result == {"score": {"$eq": -1.0}}
 
     def test_field_gt_numeric(self):
         from tqdb.lancedb_compat import _parse_sql_where

--- a/tests/test_multivector.py
+++ b/tests/test_multivector.py
@@ -99,6 +99,23 @@ def test_insert_replaces_existing_doc():
             store._db.close()
 
 
+def test_failed_replace_keeps_existing_doc():
+    d = 8
+    with _tempdir() as path:
+        store = MultiVectorStore.open(path, dimension=d, bits=2, metric="cosine")
+        try:
+            store.insert("x", _doc_tokens(d, 3, 1), document="v1")
+            with pytest.raises(ValueError, match="dimension mismatch"):
+                store.insert("x", np.zeros((2, d - 1), dtype=np.float32))
+
+            info = store.get("x")
+            assert info is not None
+            assert info["document"] == "v1"
+            assert len(store) == 1
+        finally:
+            store._db.close()
+
+
 def test_delete_removes_doc():
     d = 8
     with _tempdir() as path:


### PR DESCRIPTION
## Unit
Python/API compatibility audit

## What changed
- Made empty Chroma collections return Chroma-shaped empty get/query/delete behavior instead of opening dimensionless stores.
- Fixed LanceDB limit(0), empty-table search, and negative numeric equality parsing.
- Preserved existing MultiVectorStore documents when a replacement insert has an invalid vector dimension.
- Replaced a timing-sensitive async concurrency test with a deterministic executor fanout test.

## Validation
- .\.venv\Scripts\python.exe -m pytest -q tests/test_async_api.py tests/test_chroma_compat.py tests/test_lancedb_compat.py tests/test_compat_adversarial.py tests/test_multivector.py tests/test_import_fallbacks.py tests/test_python_api.py tests/test_rag_coverage.py tests/test_langchain_compat.py tests/test_llama_index.py tests/test_chroma_compat_coverage.py tests/test_lancedb_compat_coverage.py --tb=short -> passed (387 passed, 1 warning)
- cargo test -q --lib -> passed (471 passed; 2 ignored after all audit fixes)
- RUSTFLAGS="-D warnings" cargo check -q -> passed
- cargo check -q --manifest-path server/Cargo.toml -> passed
- .\.venv\Scripts\python.exe benchmarks\sprint_smoke.py -> passed

## Monitor Comment
CI monitor target: wait for all required GitHub Actions checks on this PR head SHA to complete successfully before merge. If a check fails, inspect logs and patch this unit branch only unless the failure is clearly external.