### PR TITLE
[codex] fix CI and packaging audit bugs

### DIFF
--- a/benchmarks/sprint_smoke.py
+++ b/benchmarks/sprint_smoke.py
@@ -26,7 +26,7 @@ except ImportError:
     print("ERROR: tqdb not installed. Run: maturin develop --release")
     sys.exit(1)
 
-# ── Parameters ──────────────────────────────────────────────────────────────
+# -- Parameters ---------------------------------------------------------------
 D = 200          # vector dimension
 N = 10_000       # corpus size
 N_Q = 500        # number of queries
@@ -38,7 +38,7 @@ RECALL_FLOOR = 0.80
 P95_LAT_MS   = 50.0
 INGEST_MIN   = 1_000.0   # vectors/second
 
-# ── Generate data ────────────────────────────────────────────────────────────
+# -- Generate data ------------------------------------------------------------
 rng = np.random.default_rng(SEED)
 corpus = rng.standard_normal((N, D)).astype(np.float32)
 corpus /= np.linalg.norm(corpus, axis=1, keepdims=True)
@@ -50,7 +50,7 @@ queries /= np.linalg.norm(queries, axis=1, keepdims=True)
 scores_gt = corpus @ queries.T               # (N, N_Q)
 true_top_k = np.argsort(-scores_gt, axis=0)[:K].T  # (N_Q, K) — row = query
 
-# ── Ingest ────────────────────────────────────────────────────────────────────
+# -- Ingest -------------------------------------------------------------------
 with tempfile.TemporaryDirectory() as tmpdir:
     db = Database.open(tmpdir, dimension=D, bits=BITS, seed=SEED, metric="ip", rerank=True)
 
@@ -60,7 +60,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     ingest_s = time.perf_counter() - t0
     throughput = N / ingest_s
 
-    # ── Search ───────────────────────────────────────────────────────────────
+    # -- Search ---------------------------------------------------------------
     latencies = []
     hits = 0
     for qi in range(N_Q):
@@ -75,12 +75,12 @@ with tempfile.TemporaryDirectory() as tmpdir:
 
     db.close()
 
-# ── Report ────────────────────────────────────────────────────────────────────
+# -- Report -------------------------------------------------------------------
 recall = hits / (N_Q * K)
 p95_ms = float(np.percentile(latencies, 95))
 p50_ms = float(np.percentile(latencies, 50))
 
-print(f"\n── Sprint Smoke ({'PASS' if recall >= RECALL_FLOOR and p95_ms <= P95_LAT_MS else 'FAIL'}) ──")
+print(f"\n-- Sprint Smoke ({'PASS' if recall >= RECALL_FLOOR and p95_ms <= P95_LAT_MS else 'FAIL'}) --")
 print(f"  Ingest:   {throughput:>8,.0f} vec/s  (min {INGEST_MIN:.0f})")
 print(f"  Recall@{K}: {recall:>8.3f}     (min {RECALL_FLOOR})")
 print(f"  P50 lat:  {p50_ms:>8.2f} ms")
@@ -97,7 +97,7 @@ if throughput < INGEST_MIN:
 if failures:
     print("\nFAILED:")
     for f in failures:
-        print(f"  ✗ {f}")
+        print(f"  X {f}")
     sys.exit(1)
 
-print("\n  ✓ All checks passed")
+print("\n  OK All checks passed")

--- a/benchmarks/sprint_smoke.py
+++ b/benchmarks/sprint_smoke.py
@@ -80,12 +80,6 @@ recall = hits / (N_Q * K)
 p95_ms = float(np.percentile(latencies, 95))
 p50_ms = float(np.percentile(latencies, 50))
 
-print(f"\n-- Sprint Smoke ({'PASS' if recall >= RECALL_FLOOR and p95_ms <= P95_LAT_MS else 'FAIL'}) --")
-print(f"  Ingest:   {throughput:>8,.0f} vec/s  (min {INGEST_MIN:.0f})")
-print(f"  Recall@{K}: {recall:>8.3f}     (min {RECALL_FLOOR})")
-print(f"  P50 lat:  {p50_ms:>8.2f} ms")
-print(f"  P95 lat:  {p95_ms:>8.2f} ms  (max {P95_LAT_MS} ms)")
-
 failures = []
 if recall < RECALL_FLOOR:
     failures.append(f"Recall@{K} {recall:.3f} < {RECALL_FLOOR}")
@@ -93,6 +87,12 @@ if p95_ms > P95_LAT_MS:
     failures.append(f"P95 latency {p95_ms:.1f} ms > {P95_LAT_MS} ms")
 if throughput < INGEST_MIN:
     failures.append(f"Throughput {throughput:.0f} vec/s < {INGEST_MIN:.0f}")
+
+print(f"\n-- Sprint Smoke ({'FAIL' if failures else 'PASS'}) --")
+print(f"  Ingest:   {throughput:>8,.0f} vec/s  (min {INGEST_MIN:.0f})")
+print(f"  Recall@{K}: {recall:>8.3f}     (min {RECALL_FLOOR})")
+print(f"  P50 lat:  {p50_ms:>8.2f} ms")
+print(f"  P95 lat:  {p95_ms:>8.2f} ms  (max {P95_LAT_MS} ms)")
 
 if failures:
     print("\nFAILED:")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,13 @@ Changelog = "https://github.com/jyunming/TurboQuantDB/releases"
 [tool.maturin]
 features = ["python", "pyo3/extension-module"]
 python-source = "python"
-include = ["python/tqdb/*.pyi", "python/tqdb/_bin/*"]
+include = [
+    "python/tqdb/*.pyi",
+    "python/tqdb/_bin/*",
+    { path = "server/Cargo.toml", format = "sdist" },
+    { path = "server/Cargo.lock", format = "sdist" },
+    { path = "server/src/**/*", format = "sdist" },
+]
 
 [tool.pytest.ini_options]
 tmp_path_retention_policy = "failed"

--- a/scripts/ci/run_recall_bench.py
+++ b/scripts/ci/run_recall_bench.py
@@ -300,7 +300,7 @@ def run_benchmark(args):
             f"FAIL: Recall@{args.k} = {recall_at_k:.1%} "
             f"(threshold: {args.recall_threshold:.0%})"
         )
-        print(f"✓ Recall threshold passed (≥{args.recall_threshold:.0%})")
+        print(f"OK Recall threshold passed (>={args.recall_threshold:.0%})")
 
     return result
 

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1678,7 +1678,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tqdb"
-version = "0.8.1"
+version = "0.8.3"
 dependencies = [
  "bincode",
  "crc32fast",


### PR DESCRIPTION
## Unit
CI and packaging audit

## What changed
- Included the Rust server crate files in sdists so tqdb-server source-build fallback has the server sources it needs.
- Synced server/Cargo.lock local tqdb dependency version with the root package version.
- Replaced Unicode-only status output in CI/local benchmark scripts with ASCII-safe output for Windows cp1252 consoles.

## Validation
- .\.venv\Scripts\python.exe benchmarks\sprint_smoke.py -> passed
- .\.venv\Scripts\python.exe scripts\ci\run_recall_bench.py --n 100 --d 16 --queries 2 --k 3 --artifact-dir tmp_pytest\recall-smoke --artifact-prefix recall_smoke -> passed
- cargo test -q --lib -> passed (471 passed; 2 ignored after all audit fixes)
- RUSTFLAGS="-D warnings" cargo check -q -> passed
- cargo check -q --manifest-path server/Cargo.toml -> passed
- .\.venv\Scripts\python.exe broad compatibility/API pytest set -> passed (387 passed, 1 warning)

## Monitor Comment
CI monitor target: wait for all required GitHub Actions checks on this PR head SHA to complete successfully before merge. If a check fails, inspect logs and patch this unit branch only unless the failure is clearly external.