### PR TITLE
[codex] update docs after audit fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ An embedded vector database with a Python API. Built around the **TurboQuant** a
 pip install tqdb
 ```
 
-Optional integration extras: `tqdb[langchain]`, `tqdb[llamaindex]`, `tqdb[migrate]` (Chroma + LanceDB import). Build from source: see [`DEVELOPMENT.md`](https://github.com/jyunming/TurboQuantDB/blob/main/DEVELOPMENT.md). Upgrading from v0.7: see [`docs/WHAT_S_NEW_0_8.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/WHAT_S_NEW_0_8.md).
+Optional integration extras: `tqdb[langchain]`, `tqdb[llamaindex]`, `tqdb[migrate]` (Chroma + LanceDB import). Build from source: see [`DEVELOPMENT.md`](https://github.com/jyunming/TurboQuantDB/blob/main/DEVELOPMENT.md). Upgrading from v0.8 dense-mode databases: see [`docs/QUANTIZER_MODES.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/QUANTIZER_MODES.md#compatibility-notes).
 
 ---
 
@@ -114,7 +114,7 @@ All numbers below come from runs on a single Windows laptop; absolute values wil
 
 ### A. Paper-validation (n=100k, brute-force, fast_mode=True)
 
-Config: dbpedia-1536, b=4, `rerank=True`, brute-force, `quantizer_type="dense"`. Matches arXiv:2504.19874 Figure 5b's bit allocation. (As of v0.9 the default at d ≥ 1024 is `"srht"`, which is faster on ingest and p50 with comparable recall — see [QUANTIZER_MODES.md](docs/QUANTIZER_MODES.md).)
+Config: dbpedia-1536, b=4, `rerank=True`, brute-force, `quantizer_type=None` (v0.9 auto-selects `"srht"` at this dimension). Matches arXiv:2504.19874 Figure 5b's bit allocation; pin `quantizer_type="dense"` when you need the paper-faithful QR rotation.
 
 | Metric | Value |
 |---|---:|
@@ -219,7 +219,7 @@ Detailed setup, pagination, hybrid wiring, and async patterns: [LangChain integr
 
 ## Async API
 
-For FastAPI / Starlette / async RAG services, `AsyncDatabase` exposes awaitable versions of every long-running operation. The Rust extension releases the GIL inside, so concurrent `await db.search(...)` calls run in real parallel.
+For FastAPI / Starlette / async RAG services, `AsyncDatabase` exposes awaitable versions of every long-running operation. Calls are dispatched through a `ThreadPoolExecutor`, so concurrent awaits do not block the event loop; Rust engine calls release the GIL while they run.
 
 ```python
 import asyncio
@@ -331,7 +331,7 @@ Full endpoint reference, environment variables, and the Server Recovery Runbook:
 
 ## Advanced features
 
-- **Two quantizer modes** — `dense` (default, best recall) and `srht` (faster ingest at high d). See [`docs/QUANTIZER_MODES.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/QUANTIZER_MODES.md).
+- **Two quantizer modes** — `quantizer_type=None` auto-selects `dense` below d=1024 and `srht` at d>=1024. Pin `dense` for paper-faithful QR/no-padding storage or `srht` for faster high-dimensional ingest and p50. See [`docs/QUANTIZER_MODES.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/QUANTIZER_MODES.md).
 - **Optional ANN index** — HNSW graph for low-latency search at n ≥ 100k; auto-fallback to brute-force when N is small.
 - **IVF coarse routing** — `db.create_coarse_index(n_clusters=256)` + `nprobe=N` to score ~6% of the corpus at very large N.
 - **MongoDB-style metadata filters** — `$eq $ne $gt $gte $lt $lte $in $nin $exists $and $or $contains`; `$in / $nin / $or` use O(1) indexed fast-paths.
@@ -341,7 +341,7 @@ Full endpoint reference, environment variables, and the Server Recovery Runbook:
 
 `MultiVectorStore` lets each document hold N token vectors and scores queries with MaxSim (`Σ_i max_j <q_i, d_j>`), useful for late-interaction retrieval experiments.
 
-This is currently a **Python-layer wrapper** over the single-vector engine; native engine-level support is planned for a future v0.9 release. The public API is designed to stay stable across that move. See [`docs/MULTI_VECTOR.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/MULTI_VECTOR.md).
+This is currently a **Python-layer wrapper** over the single-vector engine; native engine-level support remains a future hardening item. The public API is designed to stay stable across that move. See [`docs/MULTI_VECTOR.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/MULTI_VECTOR.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ An embedded vector database with a Python API. Built around the **TurboQuant** a
 pip install tqdb
 ```
 
-Optional integration extras: `tqdb[langchain]`, `tqdb[llamaindex]`, `tqdb[migrate]` (Chroma + LanceDB import). Build from source: see [`DEVELOPMENT.md`](https://github.com/jyunming/TurboQuantDB/blob/main/DEVELOPMENT.md). Upgrading from v0.8 dense-mode databases: see [`docs/QUANTIZER_MODES.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/QUANTIZER_MODES.md#compatibility-notes).
+Optional integration extras: `tqdb[langchain]`, `tqdb[llamaindex]`, `tqdb[migrate]` (Chroma + LanceDB import). Build from source: see [`DEVELOPMENT.md`](https://github.com/jyunming/TurboQuantDB/blob/main/DEVELOPMENT.md). Upgrading from v0.8 dense-mode databases: see [`docs/QUANTIZER_MODES.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/QUANTIZER_MODES.md#backward-compatibility).
 
 ---
 

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -3,7 +3,10 @@
 Three datasets from [arXiv:2504.19874](https://arxiv.org/abs/2504.19874) — n=100k vectors each.
 Full script: [`benchmarks/paper_recall_bench.py`](https://github.com/jyunming/TurboQuantDB/blob/main/benchmarks/paper_recall_bench.py).
 
-All results use `quantizer_type=None/"dense"` and `fast_mode=True, rerank=True` (MSE-only, matching paper Figure 5 bit allocation). ANN rows use HNSW (md=32, ef=128).
+The benchmark script opens databases with `quantizer_type=None`, so v0.9 runs
+`"dense"` below d=1024 and `"srht"` at d>=1024. All rows use `fast_mode=True`
+(MSE-only, matching paper Figure 5 bit allocation); rerank varies by config.
+ANN rows use HNSW (md=32, ef=128).
 
 To regenerate:
 ```bash
@@ -14,6 +17,14 @@ python benchmarks/paper_recall_bench.py --update-readme --track
 CI perf gate:
 - PR CI runs a fast smoke perf gate (`benchmarks/sprint_smoke.py`) in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
 - This is a regression tripwire (latency/recall/ingest), not a full publish benchmark replacement.
+- `sprint_smoke.py` prints a compact PASS/FAIL summary for ingest, Recall@10,
+  p50, and p95, then exits non-zero only when a gate fails. It does not write
+  JSON or update history files.
+- `paper_recall_bench.py` always writes `benchmarks/_bench_recall_results.json`
+  after a real run. `--update-readme` patches only the marked section in this
+  file, `--track` appends `benchmarks/perf_history.json` and regenerates the
+  HTML report, and `--plots-only` regenerates plots from saved JSON without
+  rerunning the benchmark.
 
 ---
 
@@ -190,12 +201,13 @@ what most RAG pipelines actually consume.
 
 ---
 
-## v0.8 features — what isn't yet benchmarked
+## Embedded Python features not yet benchmarked
 
-The v0.8 sprint added five Python-side features. Three of them have correctness coverage in the test suite but aren't yet tracked in the longitudinal perf history:
+Several Python-side features have correctness coverage in the test suite but
+aren't yet tracked in the longitudinal perf history:
 
-- **Multi-vector / MaxSim retrieval at scale** (`MultiVectorStore`) — the v0.8 wrapper is a Python layer over the existing single-vector engine. Per-config recall and latency at 10k+ docs / 80k+ tokens are pending, and will be the headline numbers when v0.9 lands the native engine integration.
-- **`AsyncDatabase` concurrent-search throughput** — `tests/test_async_api.py` includes a 50-concurrent-search proof of parallelism but no longitudinal numbers; the actual ceiling depends on user thread-pool sizing and embedder latency.
+- **Multi-vector / MaxSim retrieval at scale** (`MultiVectorStore`) — the wrapper is a Python layer over the existing single-vector engine. Per-config recall and latency at 10k+ docs / 80k+ tokens are pending and should be measured before native engine integration work.
+- **`AsyncDatabase` concurrent-search throughput** — `tests/test_async_api.py` verifies executor fan-out with a blocking fake DB and event-loop responsiveness with a real DB, but there are no longitudinal throughput numbers. The actual ceiling depends on user thread-pool sizing, CPU cores, storage, and embedder latency.
 - **Migration toolkit throughput** (`tqdb.migrate`) — the CLI prints rows/sec per run but those numbers aren't tracked in perf_history. For now, expect rates close to a plain `Database.insert_batch` loop on the same hardware.
 
 LangChain / LlamaIndex / hybrid-via-integration overhead is also not benchmarked separately. The wrappers add a small Python-layer cost per call (one filter-dict translation + one numpy conversion) which has been negligible in practice on the 1k-5k corpora the test suite uses.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -12,14 +12,15 @@ For full empirical numbers across 32 configs × 4 datasets (GloVe-200, arXiv-768
 db = Database.open(
     path,
     dimension,
-    bits=4,                 # 2 or 4 — compression bits per subspace
+    bits=4,                 # 1..8; bits=1 requires fast_mode=True. Common: 2, 4, 8.
     rerank=False,           # False (default) = MSE codes only, minimum disk
                             # True = store raw INT8 vectors for exact second-pass rescoring
-    rerank_precision=None,  # None (→ "int8"), "int8"/"i8", "int4"/"i4", "f16", "f32", "disabled"
+    rerank_precision=None,  # None (→ "int8"), "int8"/"i8", "residual_int4"/"ri4",
+                            # "int4"/"i4" (deprecated), "f16", "f32", "disabled"
     fast_mode=True,         # True (default) = MSE-only (fastest ingest, minimum disk)
                             # False = MSE + QJL residual (+5–10 pp R@1 at d ≥ 1536, rerank=False)
-    quantizer_type=None,    # None/"dense" (Haar QR) or "srht" (Hadamard)
-    metric="ip",            # "ip" (inner product) or "l2" (Euclidean)
+    quantizer_type=None,    # None auto-selects dense for d<1024, srht for d>=1024
+    metric="ip",            # "ip" (inner product), "cosine", or "l2" (Euclidean)
     seed=42,
 )
 
@@ -113,16 +114,17 @@ results = db.search(query, top_k=10, rerank_factor=5)
 
 ---
 
-### `quantizer_type` — `None`/`"dense"` vs `"srht"`
+### `quantizer_type` — auto, `"dense"`, or `"srht"`
 
 Selects the rotation applied before Lloyd-Max quantization.
 
 | quantizer_type | Rotation | Ingest cost | Recall | When to use |
 |----------------|----------|-------------|--------|-------------|
-| `None` / `"dense"` | Haar QR | O(d²) | best | Default; d < 2048 |
-| `"srht"` | SRHT (Hadamard) | O(d log d) | −1 to −3 pp | d ≥ 1536 with high throughput requirement |
+| `None` | Auto: `"dense"` for d<1024, `"srht"` for d>=1024 | dimension-aware | default | Let the library pick the v0.9 crossover |
+| `"dense"` / `"exact"` | Haar QR | O(d²) | strongest low-d / no padding | d < 1024, or when you want paper-faithful QR |
+| `"srht"` | SRHT (Hadamard) | O(d log d) | equal/slightly better in high-d public benches | d >= 1024 with high throughput or latency requirements |
 
-**Rule:** Use `"dense"` (default). Switch to `"srht"` only when ingest throughput is the primary bottleneck at d ≥ 1536 (e.g., real-time embedding pipelines).
+**Rule:** Leave `quantizer_type=None` unless you need a reproducible mode choice. Pin `"dense"` for low-dimensional or no-padding storage; pin `"srht"` for high-dimensional ingest/search speed.
 
 ---
 
@@ -149,7 +151,7 @@ Call `db.create_index()` after bulk load to build the HNSW graph.
 ```python
 db = Database.open(path, dimension=1536,
     bits=4, rerank=True, fast_mode=False,
-    quantizer_type=None)  # dense, default; rerank_precision=None → int8
+    quantizer_type="dense")  # pin dense for maximum-recall QR; rerank_precision=None → int8
 # ~149 MB for 100k vectors; R@1 ≈ 0.94–0.96 (DBpedia-1536)
 ```
 
@@ -212,7 +214,7 @@ Recommended starting config for ColBERTv2-style late interaction:
 | `dimension` | 96 (ColBERTv2) or 128 (ColBERT) | per-token dim of the model |
 | `bits` | 4 | good recall at modest disk |
 | `metric` | `"cosine"` | ColBERT vectors are unit-normalised |
-| `quantizer_type` | `"dense"` (default) | best recall |
+| `quantizer_type` | `None` or `"dense"` | auto resolves to dense at ColBERT dimensions; pin dense for reproducibility |
 
 The wrapper rejects `metric="l2"` at construction — MaxSim is a dot-product
 aggregation that doesn't generalise cleanly to lower-is-better metrics.
@@ -236,11 +238,11 @@ it on memory-constrained hosts.
 ## Decision Flowchart
 
 ```
-Start from defaults: bits=4, rerank=False, fast_mode=True, quantizer_type="dense"
+Start from defaults: bits=4, rerank=False, fast_mode=True, quantizer_type=None
 
 Need better recall?
   YES → rerank=True (+5–25 pp R@1; adds INT8 raw vectors, ~2–4× more disk)
-      → rerank_precision="int4" if storage is tight (~half disk vs int8)
+      → rerank_precision="residual_int4" if storage is tight (~31% less disk vs int8 at b=4)
       → rerank_precision="f16" for maximum precision
 
 Is d ≥ 1536 AND rerank=False?
@@ -251,9 +253,10 @@ Is N > 100k or p50 < 10ms required?
   YES → create_index() + _use_ann=True (or None for auto)
   NO  → brute-force is fine
 
-Is ingest throughput critical (streaming, d≥1536)?
-  YES → quantizer_type="srht"
-  NO  → quantizer_type="dense" (default)
+Need a fixed quantizer mode instead of dimension-aware auto?
+  d < 1024 or no-padding/paper-faithful QR → quantizer_type="dense"
+  d >= 1024 and ingest/latency matter      → quantizer_type="srht"
+  otherwise                                → keep quantizer_type=None
 ```
 
 ---

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -35,6 +35,11 @@ Both commands print one summary line per collection/table:
 OK: migrated 12345 rows in 2.4s
 ```
 
+Empty Chroma collections are reported as `empty — skipping` and do not create a
+target TQDB directory. Empty LanceDB tables are reported as `empty — nothing to
+migrate`. In both cases the command exits successfully and the programmatic API
+returns `0`.
+
 ## Programmatic API
 
 ```python
@@ -66,7 +71,7 @@ Both return the number of rows migrated.
 |-------|--------|---------|
 | ID | yes | yes (column `id`; if missing, auto-numbered as `row_N`) |
 | Vector | yes (float32) | yes (auto-detected: column `vector` or first fixed-size-list column) |
-| Metadata | yes | yes (every column other than id/vector/text) |
+| Metadata | yes; `None` metadata rows become `{}` | yes (every column other than id/vector/text) |
 | Document text | yes | yes (column `text` / `document` / `content`, in that order) |
 
 ## What's *not* preserved
@@ -78,10 +83,12 @@ Both return the number of rows migrated.
 
 ## Dimension and metric
 
-Both migrators detect the dimension from the source's vector column and pass it
-to `Database.open(dimension=…)`. The metric defaults to `cosine` — the most
-common choice for text embeddings. Change with `Database.open(metric="ip")`
-on the destination after migration if needed.
+Both migrators detect the dimension from the first non-empty source vector
+column and pass it to `Database.open(dimension=...)`. The target metric is
+`cosine`, the most common choice for text embeddings, and is fixed once the
+target database is created. If you need `metric="ip"` or `metric="l2"`, run a
+custom migration loop that opens the destination with that metric before
+inserting rows.
 
 ## Multi-collection Chroma sources
 

--- a/docs/MULTI_VECTOR.md
+++ b/docs/MULTI_VECTOR.md
@@ -12,15 +12,15 @@ syntactic signal that single-vector dense retrieval misses.
 
 ## Status
 
-This is a **Python-layer wrapper** in v0.8: token vectors are stored as
+This is a **Python-layer wrapper**: token vectors are stored as
 regular slots in the underlying `Database`; a JSON sidecar tracks the
 `doc_id → [token_id]` mapping; raw float32 token vectors are kept in a
 NumPy `.npz` sidecar for exact MaxSim scoring.
 
-A future v0.9 release will move multi-vector into the engine (native slot
-grouping in `IdPool`, on-disk MaxSim kernel) for tighter storage and native
-filter pushdown. **The public Python API is designed to stay stable across
-that move** — your code shouldn't need to change.
+Native engine-level multi-vector storage remains a future hardening item
+(native slot grouping in `IdPool`, on-disk MaxSim kernel) for tighter storage
+and native filter pushdown. **The public Python API is designed to stay stable
+across that move** — your code shouldn't need to change.
 
 ## Quick start
 
@@ -63,6 +63,14 @@ len(store)
 
 `hit` is `{"doc_id": str, "score": float, "document": str | None, "metadata": dict}`.
 
+`insert(doc_id, vectors, ...)` has replace semantics. If `doc_id` already
+exists, the old token IDs are removed from the engine and sidecars before fresh
+UUID-backed token IDs are inserted. Shape, empty-vector, and dimension checks
+run before the old document is removed; failures after that point, such as I/O
+errors during the replacement write, can leave the document absent rather than
+rolled back. Use application-level retry or a staging path for critical bulk
+replacements.
+
 ## Knobs
 
 - `oversample` (default 4): each query token asks the engine for
@@ -84,7 +92,7 @@ For ColBERTv2-style late interaction:
 | `metric` | `cosine` | ColBERT vectors are unit-normalised |
 | `oversample` | 4 | Default; raise to 8-16 for long-tail recall |
 
-## Limitations (v0.8 — temporary)
+## Limitations
 
 - Inserting `N` token vectors per document is still `O(N)` work per doc, but
   `MultiVectorStore.insert()` batches all N tokens into a single
@@ -99,4 +107,5 @@ For ColBERTv2-style late interaction:
   raises at construction time. MaxSim is a dot-product aggregation that
   doesn't generalise cleanly to lower-is-better metrics.
 
-All four are addressed by the v0.9 native engine integration.
+These are the reasons native engine-level multi-vector support remains on the
+hardening roadmap.

--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -568,7 +568,7 @@ print(col.peek(limit=3))    # dict same shape as query result
 
 **Metric mapping:** `metadata={"hnsw:space": "cosine"}` → `metric="cosine"`, `"ip"` → inner product (default), `"l2"` → L2. The metric is fixed at collection creation and cannot be changed.
 
-**Empty behavior:** `get(ids=[])` returns an empty Chroma-shaped response, not a full-table scan. `query(...)` on an empty collection returns one empty result row per query embedding. `add(ids=[], embeddings=[])` is a no-op only when the collection already has a known dimension; a brand-new collection still needs at least one embedding to establish dimension.
+**Empty behavior:** `get(ids=[])` returns an empty Chroma-shaped response, not a full-table scan. `query(...)` on an empty collection returns one empty result row per query embedding. `add(ids=[], embeddings=[])` raises `ValueError` because Chroma-compatible adds require at least one embedding to validate or establish dimension.
 
 **Not implemented:** `HttpClient`, `Settings`, server/cloud mode, `chromadb.Client()` (ephemeral), `where_document` filtering, automatic text embedding (pass pre-computed `embeddings`; or provide an `embedding_function` callable at collection creation time).
 
@@ -608,7 +608,7 @@ tbl.optimize()   # no-op; tqdb handles compaction automatically
 
 **SQL WHERE parser:** supports `field = 'value'`, `field != 'value'`, `field IN ('a', 'b', ...)` (including `id IN (...)`), and numeric comparisons (`field > 10`, `field >= 10`, `field < 10`, `field <= 10`). More complex predicates raise `NotImplementedError`.
 
-**Empty behavior:** a table without a manifest reports `count_rows()==0`; `head()`, `to_arrow()`, `to_pandas()`, and searches with no matches return empty tables/lists rather than raising. `add([])` and `add(empty_pyarrow_table)` are no-ops once table shape is known.
+**Empty behavior:** a table without a manifest reports `count_rows()==0`; `head()`, `to_arrow()`, `to_pandas()`, and searches with no matches return empty tables/lists rather than raising. `add([])` and `add(empty_pyarrow_table)` are always no-ops; they do not create a manifest or establish a brand-new table's schema.
 
 **Implemented compatibility subset:** `update(where, values)` and `merge_insert(on).when_matched_update_all().when_not_matched_insert_all().execute(data)` are supported for basic upsert/update workflows. Other merge clauses are accepted as no-ops.
 

--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -24,8 +24,8 @@ db = Database.open(
     dimension=None,          # int|None — vector dimension. Required for new databases.
                              #            Omit to reopen an existing database — the
                              #            dimension and fixed params are loaded from manifest.json.
-    bits=4,                  # int — quantization bits (any int >= 2; 2 = highest compression,
-                             #        4 = better recall (default), 8 = near-lossless)
+    bits=4,                  # int — quantization bits, 1..8. bits=1 is allowed only
+                             #        with fast_mode=True; common values are 2, 4, 8.
     seed=42,                 # int — RNG seed for quantizer, must stay the same across sessions
     metric="ip",             # str — "ip" (inner product), "cosine", or "l2"
     rerank=False,            # bool — store raw vectors for exact second-pass rescoring.
@@ -37,7 +37,8 @@ db = Database.open(
                              #        at d ≥ 1536 when rerank=False; no benefit when rerank=True.
     rerank_precision=None,   # str|None — None → "int8" (default when rerank=True)
                              #            "int8"/"i8" = INT8 per-vector-scaled (+n×(d+4) bytes)
-                             #            "int4"/"i4" = INT4 nibble-packed (+n×(⌈d/2⌉+4) bytes)
+                             #            "residual_int4"/"ri4" = residual INT4 rerank
+                             #            "int4"/"i4" = deprecated raw INT4 rerank
                              #            "f16" = float16 exact reranking (+n×d×2 bytes)
                              #            "f32" = float32 exact reranking (+n×d×4 bytes)
                              #            "disabled"/"dequant" = no extra storage (legacy)
@@ -93,12 +94,12 @@ These two parameters work together and must be understood as a pair:
 | `True` | `True` | MSE codes + INT8 raw vectors | +5–25 pp R@1 vs default; ~2–4× more disk |
 | `False` | `False` | MSE+QJL codes | d ≥ 1536: +5–10 pp R@1; d < 512: hurts recall |
 | `False` | `True` | MSE+QJL codes + INT8 raw vectors | Maximum recall at d ≥ 1536 |
-| `True` | `False` | MSE codes only | Paper Figure 5 baseline; minimum disk |
-| `False` | `False` | MSE+QJL codes only | Modest recall gain over fast_mode=True at d ≥ 1536 |
 
 **`rerank=True`** stores per-vector-scaled INT8 vectors by default for exact second-pass rescoring. The quantized pass pre-selects `rerank_factor × top_k` candidates; exact dot products on the dequantized INT8 vectors then re-rank to the final `top_k`. This consistently improves R@1 by +5–25 pp depending on dimension and bits, at ~2× lower disk cost than F16.
 
-**`fast_mode=False`** adds 1-bit QJL residual codes on top of MSE codes. At d < 512, the projections are too noisy and reduce recall. At d ≥ 1536, enough bits accumulate to add meaningful signal — gains +5–10 pp R@1 when `rerank=False`. When `rerank=True`, the QJL residuals provide secondary benefit since f16 re-scoring dominates.
+**`fast_mode=False`** adds 1-bit QJL residual codes on top of MSE codes. At d < 512, the projections are too noisy and reduce recall. At d ≥ 1536, enough bits accumulate to add meaningful signal — gains +5–10 pp R@1 when `rerank=False`. When `rerank=True`, the QJL residuals provide secondary benefit because raw-vector re-scoring dominates.
+
+Validation edge cases are intentionally Python-visible: `dimension=0`, `bits=0`, `bits>8`, `bits=1` with `fast_mode=False`, unknown `quantizer_type`, non-finite vectors, vector dimension mismatches, `top_k<=0`, `n_results<=0`, negative `limit`, and negative `offset` raise `ValueError`. `insert_batch(..., metadatas=[None, ...])` treats each `None` row as empty metadata, matching Chroma collections that have no metadata.
 
 ---
 
@@ -447,7 +448,7 @@ The delta overlay is persisted to `delta_ids.json` and survives restarts. Delete
 
 ## Async API
 
-`AsyncDatabase` is an asyncio-friendly wrapper around `Database`. Every long-running method is awaitable; the underlying call dispatches to a thread-pool executor, so concurrent `await db.search(...)` calls genuinely run in parallel (the Rust extension releases the GIL inside).
+`AsyncDatabase` is an asyncio-friendly wrapper around `Database`. Every long-running method is awaitable; the underlying call dispatches to a thread-pool executor, so concurrent awaits fan out through the pool and the event loop stays responsive. Rust engine calls release the GIL while they run; actual throughput still depends on executor size, CPU cores, and storage.
 
 ```python
 import asyncio
@@ -457,7 +458,7 @@ async def main():
     async with await AsyncDatabase.open("./mydb", dimension=1536, bits=4) as db:
         await db.insert("doc1", vec, document="...")
         results = await db.search(query, top_k=5)
-        # 50 concurrent searches — actually run in parallel:
+        # Concurrent searches fan out through the executor:
         all_results = await asyncio.gather(
             *(db.search(q, top_k=5) for q in queries)
         )
@@ -567,6 +568,8 @@ print(col.peek(limit=3))    # dict same shape as query result
 
 **Metric mapping:** `metadata={"hnsw:space": "cosine"}` → `metric="cosine"`, `"ip"` → inner product (default), `"l2"` → L2. The metric is fixed at collection creation and cannot be changed.
 
+**Empty behavior:** `get(ids=[])` returns an empty Chroma-shaped response, not a full-table scan. `query(...)` on an empty collection returns one empty result row per query embedding. `add(ids=[], embeddings=[])` is a no-op only when the collection already has a known dimension; a brand-new collection still needs at least one embedding to establish dimension.
+
 **Not implemented:** `HttpClient`, `Settings`, server/cloud mode, `chromadb.Client()` (ephemeral), `where_document` filtering, automatic text embedding (pass pre-computed `embeddings`; or provide an `embedding_function` callable at collection creation time).
 
 **Where-filter operators supported:** `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$and`, `$or`, `$exists`, `$contains`.
@@ -605,7 +608,11 @@ tbl.optimize()   # no-op; tqdb handles compaction automatically
 
 **SQL WHERE parser:** supports `field = 'value'`, `field != 'value'`, `field IN ('a', 'b', ...)` (including `id IN (...)`), and numeric comparisons (`field > 10`, `field >= 10`, `field < 10`, `field <= 10`). More complex predicates raise `NotImplementedError`.
 
-**Not implemented:** `update(where, values)`, `merge_insert()`, `create_fts_index`, `create_scalar_index`, `drop_database`, remote/cloud URIs.
+**Empty behavior:** a table without a manifest reports `count_rows()==0`; `head()`, `to_arrow()`, `to_pandas()`, and searches with no matches return empty tables/lists rather than raising. `add([])` and `add(empty_pyarrow_table)` are no-ops once table shape is known.
+
+**Implemented compatibility subset:** `update(where, values)` and `merge_insert(on).when_matched_update_all().when_not_matched_insert_all().execute(data)` are supported for basic upsert/update workflows. Other merge clauses are accepted as no-ops.
+
+**Not implemented:** `create_fts_index`, `create_scalar_index`, `drop_database`, remote/cloud URIs.
 
 ---
 

--- a/docs/SERVER_API.md
+++ b/docs/SERVER_API.md
@@ -2,11 +2,10 @@
 
 Optional Axum HTTP service providing TurboQuantDB in multi-tenant server mode. Use this when you need REST API access, multi-tenancy, authentication, quotas, or async job management. For single-process Python use, the embedded `tqdb` package is simpler.
 
-## v0.8 feature availability
+## Embedded feature availability
 
-The v0.8 sprint shipped five Python-side features. Most are **embedded-Python only**
-— they don't have HTTP equivalents on the server. Use the embedded `tqdb` package
-when you need them.
+Several Python-side features are **embedded-Python only** — they don't have HTTP
+equivalents on the server. Use the embedded `tqdb` package when you need them.
 
 | Feature | Embedded Python | HTTP server |
 |---|---|---|
@@ -17,14 +16,15 @@ when you need them.
 | Migration toolkit (`tqdb.migrate`, CLI) | yes | n/a — offline batch tool |
 | BM25 hybrid (`db.search(..., hybrid={...})`, v0.7) | yes | yes — `hybrid` field in `/query` request |
 
-Bridging integrations into server mode is a v0.9-or-later candidate; the embedded
-mode is canonical for those workflows today.
+Bridging integrations into server mode remains a future hardening item; the
+embedded mode is canonical for those workflows today.
 
 ## Installation
 
-The server binary ships pre-built inside the `tqdb` wheel on all supported platforms
-(Linux x86-64, macOS, Windows). **Linux arm64/aarch64** is the exception — see
-[Building from Source](#building-from-source-development-only) for that platform.
+The server binary ships pre-built inside the `tqdb` wheel on Linux x86-64,
+macOS, and Windows. **Linux arm64/aarch64** wheels do not bundle the server
+binary — see [Building from Source](#building-from-source-development-only) for
+that platform.
 
 ```bash
 pip install tqdb
@@ -42,7 +42,8 @@ launching to change the address, data directory, or other options (see
 
 ## Building from Source (development only)
 
-Linux arm64/aarch64 users and contributors building from the Git repo:
+Linux arm64/aarch64 users, source-distribution installs, and contributors
+building from the Git repo must build the server binary separately:
 
 ```bash
 cd server
@@ -58,6 +59,14 @@ Then launch the compiled binary:
 # Windows
 .\target\release\tqdb-server.exe
 ```
+
+The Python source distribution includes `server/Cargo.toml`, `server/Cargo.lock`,
+and `server/src/**`, but `pip install` from sdist does not build or bundle the
+server executable automatically. The `tqdb-server` console script first looks for
+`python/tqdb/_bin/tqdb-server*` in an installed wheel, then for
+`server/target/release/tqdb-server*` in a development checkout. If neither path
+exists, it prints the missing candidate paths and the `cd server && cargo build
+--release` command.
 
 ## Environment Variables
 

--- a/docs/WHAT_S_NEW_0_8.md
+++ b/docs/WHAT_S_NEW_0_8.md
@@ -9,7 +9,7 @@ Five new Python-side features and **no breaking changes**:
 1. **Multi-vector / ColBERT** retrieval with MaxSim scoring.
 2. **LangChain v2** native `VectorStore` ABC.
 3. **LlamaIndex** native `BasePydanticVectorStore` integration.
-4. **`AsyncDatabase`** — asyncio facade with real concurrency (PyO3 releases the GIL).
+4. **`AsyncDatabase`** — asyncio facade that dispatches long-running calls through a thread-pool executor; Rust engine calls release the GIL while they run.
 5. **`tqdb.migrate`** — one-command import from existing Chroma / LanceDB collections.
 
 Existing v0.7 code keeps working. Upgrade is `pip install -U tqdb`.
@@ -71,13 +71,15 @@ from tqdb.aio import AsyncDatabase
 
 async with await AsyncDatabase.open("./mydb", dimension=1536) as db:
     await db.insert("doc1", vec)
-    # 50 concurrent searches — actually run in parallel:
+    # Concurrent searches fan out through the executor:
     all_results = await asyncio.gather(*(db.search(q, top_k=5) for q in queries))
 ```
 
-Thread-pool-backed wrapper over the sync `Database`. Because every PyO3 method
-already releases the GIL via `py.allow_threads`, concurrent `await` calls
-genuinely parallelise — the existing test suite includes a 50-task proof.
+Thread-pool-backed wrapper over the sync `Database`. Because Rust engine calls
+release the GIL while they run, concurrent awaits can proceed without blocking
+the event loop. Current tests verify executor fan-out with a blocking fake DB
+and event-loop responsiveness with a real DB; they are not a throughput
+benchmark.
 
 Full guide: [`docs/PYTHON_API.md` — Async API](PYTHON_API.md#async-api).
 
@@ -125,14 +127,14 @@ The new class implements the full LangChain `VectorStore` ABC, so calls like
 `store.add_documents(...)`, `store.similarity_search_with_score(...)`, and
 `store.from_texts(...)` work as documented in the LangChain reference.
 
-## What's coming in v0.9
+## After v0.8
 
-The v0.9-v1.0 hardening sprint targets:
+The v0.9-v1.0 hardening work targets:
 
-- **Native multi-vector engine integration** — replaces the v0.8 Python-layer
+- **Native multi-vector engine integration** — replaces the Python-layer
   wrapper with `IdPool` doc-id grouping, an on-disk MaxSim kernel, and native
   filter pushdown. Same public Python API, much tighter storage and faster search.
-- Server mode v0.8 feature parity (LangChain / LlamaIndex / multi-vector exposed
+- Server mode feature parity (LangChain / LlamaIndex / multi-vector exposed
   over HTTP) is a candidate but not yet committed.
 - Pre-1.0 hardening: `≥80%` test coverage, `.unwrap()` audit pass 2, API-key
   authentication baseline, complete `0.x → 1.0` migration guide.

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -15,7 +15,7 @@ module.
 
 ## Related guides
 
-These aren't strictly "integrations" but cover related v0.8 surfaces and live
+These aren't strictly "integrations" but cover related embedded surfaces and live
 one directory up:
 
 - **Multi-vector / ColBERT** — late-interaction retrieval with MaxSim scoring.

--- a/docs/research/v0.9-quantizer-recommendation.md
+++ b/docs/research/v0.9-quantizer-recommendation.md
@@ -228,11 +228,10 @@ bf16 vs the prior f32 baseline).
    0.91. The defaults are dim-blind; making them dim-aware would push the
    sub-ms p50 case (small d) much closer to snapvec IVFPQ's 0.20 ms.
 
-3. **Public bench refresh.** `paper_recall_bench.py` runs with explicit
-   `quantizer_type` choices today; the current README tables are unaffected by
-   the auto-default change. After v0.9 ships, update README headline numbers
-   to reflect the SRHT default at d ≥ 1024 (which gives slightly better recall
-   *and* much faster ingest).
+3. **Public bench refresh.** `paper_recall_bench.py` now opens databases with
+   `quantizer_type=None`, so v0.9 benchmark runs exercise the auto-default:
+   dense below d=1024 and SRHT at d ≥ 1024. Refresh README headline numbers
+   from a clean tracked run before release.
 
 4. **PQ as opt-in `quantizer_type="pq"`?** Marginal benefit over SRHT; would
    add training-time burden inconsistent with the "zero training" pitch.


### PR DESCRIPTION
## Unit
Documentation audit after code audit fixes

## What changed
- Aligned v0.9 quantizer default docs with dimension-aware auto mode: dense below d=1024, SRHT at d>=1024.
- Updated Python API docs for validation edge cases, async executor fan-out wording, Chroma/LanceDB empty behavior, and compatibility support.
- Clarified MultiVector replace semantics and remaining native-engine roadmap items.
- Documented server sdist/source-build behavior and benchmark script output behavior.

## Validation
- `git diff --check -- README.md docs` -> passed
- Targeted stale-wording grep for old v0.9/default/concurrency/compat phrases -> no matches

## Monitor Comment
CI monitor target: wait for all required GitHub Actions checks on this PR head SHA to complete successfully before merge. If a check fails, inspect logs and patch this docs branch only unless the failure is clearly external.