### PR TITLE
[codex] bump release version to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to TurboQuantDB are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.0] — 2026-05-19
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,7 +2108,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tqdb"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tqdb"
-version = "0.8.3"
+version = "0.9.0"
 edition = "2024"
 license = "Apache-2.0"
 description = "Embedded vector database with zero-training-time two-stage quantization (TurboQuant)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tqdb"
-version = "0.8.3"
+version = "0.9.0"
 description = "Embedded vector database using the TurboQuant algorithm (arXiv:2504.19874) — zero training, 2-4 bit compression, fast inner-product search"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1678,7 +1678,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tqdb"
-version = "0.8.3"
+version = "0.9.0"
 dependencies = [
  "bincode",
  "crc32fast",


### PR DESCRIPTION
## Summary
- bump Rust and Python package versions to 0.9.0
- stamp the changelog's v0.9.0 release section for 2026-05-19
- sync root and server Cargo.lock package versions

## Verification
- cargo check -q
- cargo check -q --manifest-path server/Cargo.toml

I will monitor review comments and CI for this PR before merge.