### PR TITLE
[codex] audit hardening fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,5 @@ docs/SERVER_DESIGN.md
 /.venv-dev/
 /benchmarks/_smoke_v09.py
 /benchmarks/_verify_bf16_recall.py
+/benchmarks/_bench_identity_baseline.py
+/benchmarks/_bench_identity_results.json

--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,8 @@ convert_pdf.py
 /benchmarks/_combine_bench_results.py
 /benchmarks/_vector_store_compare.py
 /benchmarks/_bench_rotation_compare.py
+/benchmarks/_bench_tqfamily_compare.py
+/benchmarks/_smoke_tqfamily.py
 /benchmarks/compare_bench.py
 /benchmarks/hamming_nav_bench.py
 /benchmarks/ingest_speedup_bench.py
@@ -135,3 +137,16 @@ benchmarks/_private_plots_perf.png
 python/tqdb/_bin/tqdb-server
 python/tqdb/_bin/tqdb-server.exe
 docs/SERVER_DESIGN.md
+/benchmarks/_inspect_disk_layout.py
+/benchmarks/_bench_tqfamily_dim_sweep.py
+/benchmarks/_bench_tqfamily_dim_results.json
+/benchmarks/_bench_tqfamily_dim*.log
+/benchmarks/_inspect_srht_layout.py
+/benchmarks/_bench_more_quantizers.py
+/benchmarks/_bench_more_quantizers_results.json
+/benchmarks/_bench_tqdb_routing.py
+/benchmarks/_bench_tqdb_routing_results.json
+/benchmarks/_bench_tqdb_routing*.log
+/.venv-dev/
+/benchmarks/_smoke_v09.py
+/benchmarks/_verify_bf16_recall.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- **`quantizer_type=None` default is now dimension-aware.** Picks `"dense"` (Haar QR) for `d < 1024` and `"srht"` (Walsh–Hadamard) for `d >= 1024`. Empirical wins for SRHT once the rotation dominates ingest/latency cost: 2–3× ingest throughput, 1.5–3× lower p50 latency, recall equal or slightly better than dense in the public bench (R@1 0.962 vs 0.958 at d=1536 b=4 rerank=F; 0.980 vs 0.963 at d=3072 b=4 rerank=F). Below d=1024 the SRHT pow2-padding tax wipes the win so dense remains the default. To restore explicit control, pass `quantizer_type="dense"` or `quantizer_type="srht"`.
+
+### Performance
+
+- **bf16 storage for the dense Haar QR rotation matrix.** `quantizer.bin` is now ~50% smaller for `quantizer_type="dense"` databases: 9 MB → 4.5 MB at d=1536, 36 MB → 18 MB at d=3072. The matrix is rehydrated to f32 in memory at load time, so the rotation hot path is unchanged. Recall verified unchanged on GloVe-200 with 10k queries (ΔR@1 = +0.0002).
+
+### Migration
+
+- **v0.8 → v0.9 dense-mode databases need to be rebuilt.** The bf16 rotation storage is bincode-incompatible with v0.8.x format. SRHT-mode databases reopen cleanly; only `quantizer_type="dense"` (or the legacy `"exact"` alias) is affected. There is no automatic migration in v0.9 — re-quantize from source vectors. A polish migration tool may follow in v0.10+.
+
 ---
 
 ## [0.8.3] — 2026-05-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Migration
 
-- **v0.8 → v0.9 dense-mode databases need to be rebuilt.** The bf16 rotation storage is bincode-incompatible with v0.8.x format. SRHT-mode databases reopen cleanly; only `quantizer_type="dense"` (or the legacy `"exact"` alias) is affected. There is no automatic migration in v0.9 — re-quantize from source vectors. A polish migration tool may follow in v0.10+.
+- **Dense-mode databases created before bf16 rotation storage need to be rebuilt.** The bf16 rotation storage is bincode-incompatible with the earlier dense rotation format. SRHT-mode databases reopen cleanly; only `quantizer_type="dense"` (or the legacy `"exact"` alias) is affected. There is no automatic migration yet — re-quantize from source vectors. A polish migration tool may follow in a later patch.
 
 ---
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,7 +46,7 @@ cargo test --test integration_tests
 cargo test --test bench_search
 cargo test --test bench_batch_crud
 cargo test --test test_bm25                # v0.7 BM25 + hybrid integration
-cargo test --test test_multi_vector        # if/when v0.9 lands native multi-vector
+cargo test --test test_multi_vector        # if/when native multi-vector lands
 
 # Full Python test suite (requires optional integration deps)
 maturin develop --release

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ All numbers below come from runs on a single Windows laptop; absolute values wil
 
 ### A. Paper-validation (n=100k, brute-force, fast_mode=True)
 
-Config: dbpedia-1536, b=4, `rerank=True`, brute-force, `quantizer_type=None` (dense). Matches arXiv:2504.19874 Figure 5b's bit allocation.
+Config: dbpedia-1536, b=4, `rerank=True`, brute-force, `quantizer_type="dense"`. Matches arXiv:2504.19874 Figure 5b's bit allocation. (As of v0.9 the default at d ≥ 1024 is `"srht"`, which is faster on ingest and p50 with comparable recall — see [QUANTIZER_MODES.md](docs/QUANTIZER_MODES.md).)
 
 | Metric | Value |
 |---|---:|
@@ -240,7 +240,11 @@ Pass `executor=` to share a thread pool across multiple databases or to control 
 
 ## Configurations for common goals
 
-`rerank=True` stores raw INT8 vectors alongside compressed codes for exact second-pass rescoring. `fast_mode=True` (default) uses MSE-only quantization — optimal for d < 1536.
+`rerank=True` stores raw INT8 vectors alongside compressed codes for exact second-pass rescoring. The default is `rerank=False` for compression-first storage; turn it on when you need the extra recall.
+
+> **When do you actually need rerank?** Below d ≈ 768 the recall lift from rerank is large (+15–30 pp R@1) and worth the disk. From d ≥ 1536 with `bits=4`, brute-force `rerank=False` already hits R@1 ≈ 0.96 — rerank pushes that to 0.997 but doubles disk. For most production embedding shapes (1536, 3072), `rerank=False` is the right default.
+
+`fast_mode=True` (default) uses MSE-only quantization — optimal for d < 1536.
 
 ```python
 from tqdb import Database

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ All numbers below come from runs on a single Windows laptop; absolute values wil
 
 ### A. Paper-validation (n=100k, brute-force, fast_mode=True)
 
-Config: dbpedia-1536, b=4, `rerank=True`, brute-force, `quantizer_type=None` (v0.9 auto-selects `"srht"` at this dimension). Matches arXiv:2504.19874 Figure 5b's bit allocation; pin `quantizer_type="dense"` when you need the paper-faithful QR rotation.
+Config: dbpedia-1536, b=4, `rerank=True`, brute-force, `quantizer_type=None` (auto-selects `"srht"` at this dimension). Matches arXiv:2504.19874 Figure 5b's bit allocation; pin `quantizer_type="dense"` when you need the paper-faithful QR rotation.
 
 | Metric | Value |
 |---|---:|

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ An embedded vector database with a Python API. Built around the **TurboQuant** a
 pip install tqdb
 ```
 
-Optional integration extras: `tqdb[langchain]`, `tqdb[llamaindex]`, `tqdb[migrate]` (Chroma + LanceDB import). Build from source: see [`DEVELOPMENT.md`](https://github.com/jyunming/TurboQuantDB/blob/main/DEVELOPMENT.md). Upgrading from v0.7: see [`docs/WHAT_S_NEW_0_8.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/WHAT_S_NEW_0_8.md).
+Optional integration extras: `tqdb[langchain]`, `tqdb[llamaindex]`, `tqdb[migrate]` (Chroma + LanceDB import). Build from source: see [`DEVELOPMENT.md`](https://github.com/jyunming/TurboQuantDB/blob/main/DEVELOPMENT.md). Upgrading from v0.8 dense-mode databases: see [`docs/QUANTIZER_MODES.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/QUANTIZER_MODES.md#backward-compatibility).
 
 ---
 
@@ -114,7 +114,7 @@ All numbers below come from runs on a single Windows laptop; absolute values wil
 
 ### A. Paper-validation (n=100k, brute-force, fast_mode=True)
 
-Config: dbpedia-1536, b=4, `rerank=True`, brute-force, `quantizer_type="dense"`. Matches arXiv:2504.19874 Figure 5b's bit allocation. (As of v0.9 the default at d ≥ 1024 is `"srht"`, which is faster on ingest and p50 with comparable recall — see [QUANTIZER_MODES.md](docs/QUANTIZER_MODES.md).)
+Config: dbpedia-1536, b=4, `rerank=True`, brute-force, `quantizer_type=None` (v0.9 auto-selects `"srht"` at this dimension). Matches arXiv:2504.19874 Figure 5b's bit allocation; pin `quantizer_type="dense"` when you need the paper-faithful QR rotation.
 
 | Metric | Value |
 |---|---:|
@@ -219,7 +219,7 @@ Detailed setup, pagination, hybrid wiring, and async patterns: [LangChain integr
 
 ## Async API
 
-For FastAPI / Starlette / async RAG services, `AsyncDatabase` exposes awaitable versions of every long-running operation. The Rust extension releases the GIL inside, so concurrent `await db.search(...)` calls run in real parallel.
+For FastAPI / Starlette / async RAG services, `AsyncDatabase` exposes awaitable versions of every long-running operation. Calls are dispatched through a `ThreadPoolExecutor`, so concurrent awaits do not block the event loop; Rust engine calls release the GIL while they run.
 
 ```python
 import asyncio
@@ -331,7 +331,7 @@ Full endpoint reference, environment variables, and the Server Recovery Runbook:
 
 ## Advanced features
 
-- **Two quantizer modes** — `dense` (default, best recall) and `srht` (faster ingest at high d). See [`docs/QUANTIZER_MODES.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/QUANTIZER_MODES.md).
+- **Two quantizer modes** — `quantizer_type=None` auto-selects `dense` below d=1024 and `srht` at d>=1024. Pin `dense` for paper-faithful QR/no-padding storage or `srht` for faster high-dimensional ingest and p50. See [`docs/QUANTIZER_MODES.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/QUANTIZER_MODES.md).
 - **Optional ANN index** — HNSW graph for low-latency search at n ≥ 100k; auto-fallback to brute-force when N is small.
 - **IVF coarse routing** — `db.create_coarse_index(n_clusters=256)` + `nprobe=N` to score ~6% of the corpus at very large N.
 - **MongoDB-style metadata filters** — `$eq $ne $gt $gte $lt $lte $in $nin $exists $and $or $contains`; `$in / $nin / $or` use O(1) indexed fast-paths.
@@ -341,7 +341,7 @@ Full endpoint reference, environment variables, and the Server Recovery Runbook:
 
 `MultiVectorStore` lets each document hold N token vectors and scores queries with MaxSim (`Σ_i max_j <q_i, d_j>`), useful for late-interaction retrieval experiments.
 
-This is currently a **Python-layer wrapper** over the single-vector engine; native engine-level support is planned for a future v0.9 release. The public API is designed to stay stable across that move. See [`docs/MULTI_VECTOR.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/MULTI_VECTOR.md).
+This is currently a **Python-layer wrapper** over the single-vector engine; native engine-level support remains a future hardening item. The public API is designed to stay stable across that move. See [`docs/MULTI_VECTOR.md`](https://github.com/jyunming/TurboQuantDB/blob/main/docs/MULTI_VECTOR.md).
 
 ---
 

--- a/benchmarks/sprint_smoke.py
+++ b/benchmarks/sprint_smoke.py
@@ -26,7 +26,7 @@ except ImportError:
     print("ERROR: tqdb not installed. Run: maturin develop --release")
     sys.exit(1)
 
-# ── Parameters ──────────────────────────────────────────────────────────────
+# -- Parameters ---------------------------------------------------------------
 D = 200          # vector dimension
 N = 10_000       # corpus size
 N_Q = 500        # number of queries
@@ -38,7 +38,7 @@ RECALL_FLOOR = 0.80
 P95_LAT_MS   = 50.0
 INGEST_MIN   = 1_000.0   # vectors/second
 
-# ── Generate data ────────────────────────────────────────────────────────────
+# -- Generate data ------------------------------------------------------------
 rng = np.random.default_rng(SEED)
 corpus = rng.standard_normal((N, D)).astype(np.float32)
 corpus /= np.linalg.norm(corpus, axis=1, keepdims=True)
@@ -50,7 +50,7 @@ queries /= np.linalg.norm(queries, axis=1, keepdims=True)
 scores_gt = corpus @ queries.T               # (N, N_Q)
 true_top_k = np.argsort(-scores_gt, axis=0)[:K].T  # (N_Q, K) — row = query
 
-# ── Ingest ────────────────────────────────────────────────────────────────────
+# -- Ingest -------------------------------------------------------------------
 with tempfile.TemporaryDirectory() as tmpdir:
     db = Database.open(tmpdir, dimension=D, bits=BITS, seed=SEED, metric="ip", rerank=True)
 
@@ -60,7 +60,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     ingest_s = time.perf_counter() - t0
     throughput = N / ingest_s
 
-    # ── Search ───────────────────────────────────────────────────────────────
+    # -- Search ---------------------------------------------------------------
     latencies = []
     hits = 0
     for qi in range(N_Q):
@@ -75,16 +75,10 @@ with tempfile.TemporaryDirectory() as tmpdir:
 
     db.close()
 
-# ── Report ────────────────────────────────────────────────────────────────────
+# -- Report -------------------------------------------------------------------
 recall = hits / (N_Q * K)
 p95_ms = float(np.percentile(latencies, 95))
 p50_ms = float(np.percentile(latencies, 50))
-
-print(f"\n── Sprint Smoke ({'PASS' if recall >= RECALL_FLOOR and p95_ms <= P95_LAT_MS else 'FAIL'}) ──")
-print(f"  Ingest:   {throughput:>8,.0f} vec/s  (min {INGEST_MIN:.0f})")
-print(f"  Recall@{K}: {recall:>8.3f}     (min {RECALL_FLOOR})")
-print(f"  P50 lat:  {p50_ms:>8.2f} ms")
-print(f"  P95 lat:  {p95_ms:>8.2f} ms  (max {P95_LAT_MS} ms)")
 
 failures = []
 if recall < RECALL_FLOOR:
@@ -94,10 +88,16 @@ if p95_ms > P95_LAT_MS:
 if throughput < INGEST_MIN:
     failures.append(f"Throughput {throughput:.0f} vec/s < {INGEST_MIN:.0f}")
 
+print(f"\n-- Sprint Smoke ({'FAIL' if failures else 'PASS'}) --")
+print(f"  Ingest:   {throughput:>8,.0f} vec/s  (min {INGEST_MIN:.0f})")
+print(f"  Recall@{K}: {recall:>8.3f}     (min {RECALL_FLOOR})")
+print(f"  P50 lat:  {p50_ms:>8.2f} ms")
+print(f"  P95 lat:  {p95_ms:>8.2f} ms  (max {P95_LAT_MS} ms)")
+
 if failures:
     print("\nFAILED:")
     for f in failures:
-        print(f"  ✗ {f}")
+        print(f"  X {f}")
     sys.exit(1)
 
-print("\n  ✓ All checks passed")
+print("\n  OK All checks passed")

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -3,7 +3,10 @@
 Three datasets from [arXiv:2504.19874](https://arxiv.org/abs/2504.19874) — n=100k vectors each.
 Full script: [`benchmarks/paper_recall_bench.py`](https://github.com/jyunming/TurboQuantDB/blob/main/benchmarks/paper_recall_bench.py).
 
-All results use `quantizer_type=None/"dense"` and `fast_mode=True, rerank=True` (MSE-only, matching paper Figure 5 bit allocation). ANN rows use HNSW (md=32, ef=128).
+The benchmark script opens databases with `quantizer_type=None`, so v0.9 runs
+`"dense"` below d=1024 and `"srht"` at d>=1024. All rows use `fast_mode=True`
+(MSE-only, matching paper Figure 5 bit allocation); rerank varies by config.
+ANN rows use HNSW (md=32, ef=128).
 
 To regenerate:
 ```bash
@@ -14,6 +17,14 @@ python benchmarks/paper_recall_bench.py --update-readme --track
 CI perf gate:
 - PR CI runs a fast smoke perf gate (`benchmarks/sprint_smoke.py`) in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
 - This is a regression tripwire (latency/recall/ingest), not a full publish benchmark replacement.
+- `sprint_smoke.py` prints a compact PASS/FAIL summary for ingest, Recall@10,
+  p50, and p95, then exits non-zero only when a gate fails. It does not write
+  JSON or update history files.
+- `paper_recall_bench.py` always writes `benchmarks/_bench_recall_results.json`
+  after a real run. `--update-readme` patches only the marked section in this
+  file, `--track` appends `benchmarks/perf_history.json` and regenerates the
+  HTML report, and `--plots-only` regenerates plots from saved JSON without
+  rerunning the benchmark.
 
 ---
 
@@ -190,12 +201,13 @@ what most RAG pipelines actually consume.
 
 ---
 
-## v0.8 features — what isn't yet benchmarked
+## Embedded Python features not yet benchmarked
 
-The v0.8 sprint added five Python-side features. Three of them have correctness coverage in the test suite but aren't yet tracked in the longitudinal perf history:
+Several Python-side features have correctness coverage in the test suite but
+aren't yet tracked in the longitudinal perf history:
 
-- **Multi-vector / MaxSim retrieval at scale** (`MultiVectorStore`) — the v0.8 wrapper is a Python layer over the existing single-vector engine. Per-config recall and latency at 10k+ docs / 80k+ tokens are pending, and will be the headline numbers when v0.9 lands the native engine integration.
-- **`AsyncDatabase` concurrent-search throughput** — `tests/test_async_api.py` includes a 50-concurrent-search proof of parallelism but no longitudinal numbers; the actual ceiling depends on user thread-pool sizing and embedder latency.
+- **Multi-vector / MaxSim retrieval at scale** (`MultiVectorStore`) — the wrapper is a Python layer over the existing single-vector engine. Per-config recall and latency at 10k+ docs / 80k+ tokens are pending and should be measured before native engine integration work.
+- **`AsyncDatabase` concurrent-search throughput** — `tests/test_async_api.py` verifies executor fan-out with a blocking fake DB and event-loop responsiveness with a real DB, but there are no longitudinal throughput numbers. The actual ceiling depends on user thread-pool sizing, CPU cores, storage, and embedder latency.
 - **Migration toolkit throughput** (`tqdb.migrate`) — the CLI prints rows/sec per run but those numbers aren't tracked in perf_history. For now, expect rates close to a plain `Database.insert_batch` loop on the same hardware.
 
 LangChain / LlamaIndex / hybrid-via-integration overhead is also not benchmarked separately. The wrappers add a small Python-layer cost per call (one filter-dict translation + one numpy conversion) which has been negligible in practice on the 1k-5k corpora the test suite uses.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -3,7 +3,7 @@
 Three datasets from [arXiv:2504.19874](https://arxiv.org/abs/2504.19874) — n=100k vectors each.
 Full script: [`benchmarks/paper_recall_bench.py`](https://github.com/jyunming/TurboQuantDB/blob/main/benchmarks/paper_recall_bench.py).
 
-The benchmark script opens databases with `quantizer_type=None`, so v0.9 runs
+The benchmark script opens databases with `quantizer_type=None`, so current runs
 `"dense"` below d=1024 and `"srht"` at d>=1024. All rows use `fast_mode=True`
 (MSE-only, matching paper Figure 5 bit allocation); rerank varies by config.
 ANN rows use HNSW (md=32, ef=128).

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -120,7 +120,7 @@ Selects the rotation applied before Lloyd-Max quantization.
 
 | quantizer_type | Rotation | Ingest cost | Recall | When to use |
 |----------------|----------|-------------|--------|-------------|
-| `None` | Auto: `"dense"` for d<1024, `"srht"` for d>=1024 | dimension-aware | default | Let the library pick the v0.9 crossover |
+| `None` | Auto: `"dense"` for d<1024, `"srht"` for d>=1024 | dimension-aware | default | Let the library pick the dimension crossover |
 | `"dense"` / `"exact"` | Haar QR | O(d²) | strongest low-d / no padding | d < 1024, or when you want paper-faithful QR |
 | `"srht"` | SRHT (Hadamard) | O(d log d) | equal/slightly better in high-d public benches | d >= 1024 with high throughput or latency requirements |
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -12,14 +12,15 @@ For full empirical numbers across 32 configs × 4 datasets (GloVe-200, arXiv-768
 db = Database.open(
     path,
     dimension,
-    bits=4,                 # 2 or 4 — compression bits per subspace
+    bits=4,                 # 1..8; bits=1 requires fast_mode=True. Common: 2, 4, 8.
     rerank=False,           # False (default) = MSE codes only, minimum disk
                             # True = store raw INT8 vectors for exact second-pass rescoring
-    rerank_precision=None,  # None (→ "int8"), "int8"/"i8", "int4"/"i4", "f16", "f32", "disabled"
+    rerank_precision=None,  # None (→ "int8"), "int8"/"i8", "residual_int4"/"ri4",
+                            # "int4"/"i4" (deprecated), "f16", "f32", "disabled"
     fast_mode=True,         # True (default) = MSE-only (fastest ingest, minimum disk)
                             # False = MSE + QJL residual (+5–10 pp R@1 at d ≥ 1536, rerank=False)
-    quantizer_type=None,    # None/"dense" (Haar QR) or "srht" (Hadamard)
-    metric="ip",            # "ip" (inner product) or "l2" (Euclidean)
+    quantizer_type=None,    # None auto-selects dense for d<1024, srht for d>=1024
+    metric="ip",            # "ip" (inner product), "cosine", or "l2" (Euclidean)
     seed=42,
 )
 
@@ -113,16 +114,17 @@ results = db.search(query, top_k=10, rerank_factor=5)
 
 ---
 
-### `quantizer_type` — `None`/`"dense"` vs `"srht"`
+### `quantizer_type` — auto, `"dense"`, or `"srht"`
 
 Selects the rotation applied before Lloyd-Max quantization.
 
 | quantizer_type | Rotation | Ingest cost | Recall | When to use |
 |----------------|----------|-------------|--------|-------------|
-| `None` / `"dense"` | Haar QR | O(d²) | best | Default; d < 2048 |
-| `"srht"` | SRHT (Hadamard) | O(d log d) | −1 to −3 pp | d ≥ 1536 with high throughput requirement |
+| `None` | Auto: `"dense"` for d<1024, `"srht"` for d>=1024 | dimension-aware | default | Let the library pick the v0.9 crossover |
+| `"dense"` / `"exact"` | Haar QR | O(d²) | strongest low-d / no padding | d < 1024, or when you want paper-faithful QR |
+| `"srht"` | SRHT (Hadamard) | O(d log d) | equal/slightly better in high-d public benches | d >= 1024 with high throughput or latency requirements |
 
-**Rule:** Use `"dense"` (default). Switch to `"srht"` only when ingest throughput is the primary bottleneck at d ≥ 1536 (e.g., real-time embedding pipelines).
+**Rule:** Leave `quantizer_type=None` unless you need a reproducible mode choice. Pin `"dense"` for low-dimensional or no-padding storage; pin `"srht"` for high-dimensional ingest/search speed.
 
 ---
 
@@ -149,7 +151,7 @@ Call `db.create_index()` after bulk load to build the HNSW graph.
 ```python
 db = Database.open(path, dimension=1536,
     bits=4, rerank=True, fast_mode=False,
-    quantizer_type=None)  # dense, default; rerank_precision=None → int8
+    quantizer_type="dense")  # pin dense for maximum-recall QR; rerank_precision=None → int8
 # ~149 MB for 100k vectors; R@1 ≈ 0.94–0.96 (DBpedia-1536)
 ```
 
@@ -212,7 +214,7 @@ Recommended starting config for ColBERTv2-style late interaction:
 | `dimension` | 96 (ColBERTv2) or 128 (ColBERT) | per-token dim of the model |
 | `bits` | 4 | good recall at modest disk |
 | `metric` | `"cosine"` | ColBERT vectors are unit-normalised |
-| `quantizer_type` | `"dense"` (default) | best recall |
+| `quantizer_type` | `None` or `"dense"` | auto resolves to dense at ColBERT dimensions; pin dense for reproducibility |
 
 The wrapper rejects `metric="l2"` at construction — MaxSim is a dot-product
 aggregation that doesn't generalise cleanly to lower-is-better metrics.
@@ -236,11 +238,11 @@ it on memory-constrained hosts.
 ## Decision Flowchart
 
 ```
-Start from defaults: bits=4, rerank=False, fast_mode=True, quantizer_type="dense"
+Start from defaults: bits=4, rerank=False, fast_mode=True, quantizer_type=None
 
 Need better recall?
   YES → rerank=True (+5–25 pp R@1; adds INT8 raw vectors, ~2–4× more disk)
-      → rerank_precision="int4" if storage is tight (~half disk vs int8)
+      → rerank_precision="residual_int4" if storage is tight (~31% less disk vs int8 at b=4)
       → rerank_precision="f16" for maximum precision
 
 Is d ≥ 1536 AND rerank=False?
@@ -251,9 +253,10 @@ Is N > 100k or p50 < 10ms required?
   YES → create_index() + _use_ann=True (or None for auto)
   NO  → brute-force is fine
 
-Is ingest throughput critical (streaming, d≥1536)?
-  YES → quantizer_type="srht"
-  NO  → quantizer_type="dense" (default)
+Need a fixed quantizer mode instead of dimension-aware auto?
+  d < 1024 or no-padding/paper-faithful QR → quantizer_type="dense"
+  d >= 1024 and ingest/latency matter      → quantizer_type="srht"
+  otherwise                                → keep quantizer_type=None
 ```
 
 ---

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -35,6 +35,11 @@ Both commands print one summary line per collection/table:
 OK: migrated 12345 rows in 2.4s
 ```
 
+Empty Chroma collections are reported as `empty — skipping` and do not create a
+target TQDB directory. Empty LanceDB tables are reported as `empty — nothing to
+migrate`. In both cases the command exits successfully and the programmatic API
+returns `0`.
+
 ## Programmatic API
 
 ```python
@@ -66,7 +71,7 @@ Both return the number of rows migrated.
 |-------|--------|---------|
 | ID | yes | yes (column `id`; if missing, auto-numbered as `row_N`) |
 | Vector | yes (float32) | yes (auto-detected: column `vector` or first fixed-size-list column) |
-| Metadata | yes | yes (every column other than id/vector/text) |
+| Metadata | yes; `None` metadata rows become `{}` | yes (every column other than id/vector/text) |
 | Document text | yes | yes (column `text` / `document` / `content`, in that order) |
 
 ## What's *not* preserved
@@ -78,10 +83,12 @@ Both return the number of rows migrated.
 
 ## Dimension and metric
 
-Both migrators detect the dimension from the source's vector column and pass it
-to `Database.open(dimension=…)`. The metric defaults to `cosine` — the most
-common choice for text embeddings. Change with `Database.open(metric="ip")`
-on the destination after migration if needed.
+Both migrators detect the dimension from the first non-empty source vector
+column and pass it to `Database.open(dimension=...)`. The target metric is
+`cosine`, the most common choice for text embeddings, and is fixed once the
+target database is created. If you need `metric="ip"` or `metric="l2"`, run a
+custom migration loop that opens the destination with that metric before
+inserting rows.
 
 ## Multi-collection Chroma sources
 

--- a/docs/MULTI_VECTOR.md
+++ b/docs/MULTI_VECTOR.md
@@ -12,15 +12,15 @@ syntactic signal that single-vector dense retrieval misses.
 
 ## Status
 
-This is a **Python-layer wrapper** in v0.8: token vectors are stored as
+This is a **Python-layer wrapper**: token vectors are stored as
 regular slots in the underlying `Database`; a JSON sidecar tracks the
 `doc_id → [token_id]` mapping; raw float32 token vectors are kept in a
 NumPy `.npz` sidecar for exact MaxSim scoring.
 
-A future v0.9 release will move multi-vector into the engine (native slot
-grouping in `IdPool`, on-disk MaxSim kernel) for tighter storage and native
-filter pushdown. **The public Python API is designed to stay stable across
-that move** — your code shouldn't need to change.
+Native engine-level multi-vector storage remains a future hardening item
+(native slot grouping in `IdPool`, on-disk MaxSim kernel) for tighter storage
+and native filter pushdown. **The public Python API is designed to stay stable
+across that move** — your code shouldn't need to change.
 
 ## Quick start
 
@@ -63,6 +63,14 @@ len(store)
 
 `hit` is `{"doc_id": str, "score": float, "document": str | None, "metadata": dict}`.
 
+`insert(doc_id, vectors, ...)` has replace semantics. If `doc_id` already
+exists, the old token IDs are removed from the engine and sidecars before fresh
+UUID-backed token IDs are inserted. Shape, empty-vector, and dimension checks
+run before the old document is removed; failures after that point, such as I/O
+errors during the replacement write, can leave the document absent rather than
+rolled back. Use application-level retry or a staging path for critical bulk
+replacements.
+
 ## Knobs
 
 - `oversample` (default 4): each query token asks the engine for
@@ -84,7 +92,7 @@ For ColBERTv2-style late interaction:
 | `metric` | `cosine` | ColBERT vectors are unit-normalised |
 | `oversample` | 4 | Default; raise to 8-16 for long-tail recall |
 
-## Limitations (v0.8 — temporary)
+## Limitations
 
 - Inserting `N` token vectors per document is still `O(N)` work per doc, but
   `MultiVectorStore.insert()` batches all N tokens into a single
@@ -99,4 +107,5 @@ For ColBERTv2-style late interaction:
   raises at construction time. MaxSim is a dot-product aggregation that
   doesn't generalise cleanly to lower-is-better metrics.
 
-All four are addressed by the v0.9 native engine integration.
+These are the reasons native engine-level multi-vector support remains on the
+hardening roadmap.

--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -46,11 +46,13 @@ db = Database.open(
     normalize=False,         # bool — L2-normalize every inserted vector and every query at
                              #        write time; makes inner-product scoring equivalent to
                              #        cosine similarity without changing the metric parameter
-    quantizer_type=None,     # str|None — None/"dense" = default Haar-uniform QR path
-                             #            (O(d²) ingest, n=d, best recall)
-                             #            "exact" is a legacy alias for "dense"
-                             #            "srht" = structured fast path (O(d log d),
-                             #            n=next_power_of_two(d), faster ingest)
+    quantizer_type=None,     # str|None — None = auto: "dense" if d<1024, "srht" if d>=1024.
+                             #            "dense" = Haar-uniform QR (O(d²) ingest, n=d).
+                             #                     Rotation matrix stored as bf16 on disk.
+                             #            "exact" is a legacy alias for "dense".
+                             #            "srht" = structured Walsh-Hadamard (O(d log d) ingest,
+                             #                    n=next_power_of_two(d), faster ingest+search at
+                             #                    d>=1024).
 )
 
 # Parameterless reopen — reads all parameters from manifest.json:
@@ -75,8 +77,11 @@ images   = Database.open("./mydb", dimension=512,  collection="images")
 
 TurboQuantDB exposes the same two-stage MSE + residual-QJL layout through two quantizer families:
 
-- **`None` / `"dense"` (default)** — Haar-uniform QR rotation + dense i.i.d. Gaussian QJL with `n = d`. Best recall; O(d²) ingest cost. `"exact"` is a legacy alias.
-- **`"srht"`** — structured Walsh-Hadamard + random-sign transforms, `n = next_power_of_two(d)`, O(d log d) ingest. Use for streaming or frequent-ingest workloads at high d.
+- **`None` (default)** — auto-pick based on dimension. `"dense"` for `d < 1024`, `"srht"` for `d >= 1024`. The crossover reflects empirical wins for SRHT once the rotation dominates ingest/latency cost.
+- **`"dense"`** — Haar-uniform QR rotation + dense i.i.d. Gaussian QJL with `n = d`. O(d²) ingest cost; rotation matrix stored as bf16 on disk (since v0.9, ~50% rotation-tax savings vs f32). `"exact"` is a legacy alias.
+- **`"srht"`** — structured Walsh-Hadamard + random-sign transforms, `n = next_power_of_two(d)`, O(d log d) ingest. At `d >= 1024` this is now the default — typically 2–3× faster ingest, 1.5–3× lower p50 latency, with recall equal to or slightly better than dense in our public-bench numbers.
+
+See [`docs/QUANTIZER_MODES.md`](QUANTIZER_MODES.md) for the full per-dim trade-off table including disk and RAM.
 
 ### `fast_mode` and `rerank` interaction
 

--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -79,7 +79,7 @@ images   = Database.open("./mydb", dimension=512,  collection="images")
 TurboQuantDB exposes the same two-stage MSE + residual-QJL layout through two quantizer families:
 
 - **`None` (default)** — auto-pick based on dimension. `"dense"` for `d < 1024`, `"srht"` for `d >= 1024`. The crossover reflects empirical wins for SRHT once the rotation dominates ingest/latency cost.
-- **`"dense"`** — Haar-uniform QR rotation + dense i.i.d. Gaussian QJL with `n = d`. O(d²) ingest cost; rotation matrix stored as bf16 on disk (since v0.9, ~50% rotation-tax savings vs f32). `"exact"` is a legacy alias.
+- **`"dense"`** — Haar-uniform QR rotation + dense i.i.d. Gaussian QJL with `n = d`. O(d²) ingest cost; rotation matrix stored as bf16 on disk (~50% rotation-tax savings vs f32). `"exact"` is a legacy alias.
 - **`"srht"`** — structured Walsh-Hadamard + random-sign transforms, `n = next_power_of_two(d)`, O(d log d) ingest. At `d >= 1024` this is now the default — typically 2–3× faster ingest, 1.5–3× lower p50 latency, with recall equal to or slightly better than dense in our public-bench numbers.
 
 See [`docs/QUANTIZER_MODES.md`](QUANTIZER_MODES.md) for the full per-dim trade-off table including disk and RAM.

--- a/docs/PYTHON_API.md
+++ b/docs/PYTHON_API.md
@@ -24,8 +24,8 @@ db = Database.open(
     dimension=None,          # int|None — vector dimension. Required for new databases.
                              #            Omit to reopen an existing database — the
                              #            dimension and fixed params are loaded from manifest.json.
-    bits=4,                  # int — quantization bits (any int >= 2; 2 = highest compression,
-                             #        4 = better recall (default), 8 = near-lossless)
+    bits=4,                  # int — quantization bits, 1..8. bits=1 is allowed only
+                             #        with fast_mode=True; common values are 2, 4, 8.
     seed=42,                 # int — RNG seed for quantizer, must stay the same across sessions
     metric="ip",             # str — "ip" (inner product), "cosine", or "l2"
     rerank=False,            # bool — store raw vectors for exact second-pass rescoring.
@@ -37,7 +37,8 @@ db = Database.open(
                              #        at d ≥ 1536 when rerank=False; no benefit when rerank=True.
     rerank_precision=None,   # str|None — None → "int8" (default when rerank=True)
                              #            "int8"/"i8" = INT8 per-vector-scaled (+n×(d+4) bytes)
-                             #            "int4"/"i4" = INT4 nibble-packed (+n×(⌈d/2⌉+4) bytes)
+                             #            "residual_int4"/"ri4" = residual INT4 rerank
+                             #            "int4"/"i4" = deprecated raw INT4 rerank
                              #            "f16" = float16 exact reranking (+n×d×2 bytes)
                              #            "f32" = float32 exact reranking (+n×d×4 bytes)
                              #            "disabled"/"dequant" = no extra storage (legacy)
@@ -93,12 +94,12 @@ These two parameters work together and must be understood as a pair:
 | `True` | `True` | MSE codes + INT8 raw vectors | +5–25 pp R@1 vs default; ~2–4× more disk |
 | `False` | `False` | MSE+QJL codes | d ≥ 1536: +5–10 pp R@1; d < 512: hurts recall |
 | `False` | `True` | MSE+QJL codes + INT8 raw vectors | Maximum recall at d ≥ 1536 |
-| `True` | `False` | MSE codes only | Paper Figure 5 baseline; minimum disk |
-| `False` | `False` | MSE+QJL codes only | Modest recall gain over fast_mode=True at d ≥ 1536 |
 
 **`rerank=True`** stores per-vector-scaled INT8 vectors by default for exact second-pass rescoring. The quantized pass pre-selects `rerank_factor × top_k` candidates; exact dot products on the dequantized INT8 vectors then re-rank to the final `top_k`. This consistently improves R@1 by +5–25 pp depending on dimension and bits, at ~2× lower disk cost than F16.
 
-**`fast_mode=False`** adds 1-bit QJL residual codes on top of MSE codes. At d < 512, the projections are too noisy and reduce recall. At d ≥ 1536, enough bits accumulate to add meaningful signal — gains +5–10 pp R@1 when `rerank=False`. When `rerank=True`, the QJL residuals provide secondary benefit since f16 re-scoring dominates.
+**`fast_mode=False`** adds 1-bit QJL residual codes on top of MSE codes. At d < 512, the projections are too noisy and reduce recall. At d ≥ 1536, enough bits accumulate to add meaningful signal — gains +5–10 pp R@1 when `rerank=False`. When `rerank=True`, the QJL residuals provide secondary benefit because raw-vector re-scoring dominates.
+
+Validation edge cases are intentionally Python-visible: `dimension=0`, `bits=0`, `bits>8`, `bits=1` with `fast_mode=False`, unknown `quantizer_type`, non-finite vectors, vector dimension mismatches, `top_k<=0`, `n_results<=0`, negative `limit`, and negative `offset` raise `ValueError`. `insert_batch(..., metadatas=[None, ...])` treats each `None` row as empty metadata, matching Chroma collections that have no metadata.
 
 ---
 
@@ -447,7 +448,7 @@ The delta overlay is persisted to `delta_ids.json` and survives restarts. Delete
 
 ## Async API
 
-`AsyncDatabase` is an asyncio-friendly wrapper around `Database`. Every long-running method is awaitable; the underlying call dispatches to a thread-pool executor, so concurrent `await db.search(...)` calls genuinely run in parallel (the Rust extension releases the GIL inside).
+`AsyncDatabase` is an asyncio-friendly wrapper around `Database`. Every long-running method is awaitable; the underlying call dispatches to a thread-pool executor, so concurrent awaits fan out through the pool and the event loop stays responsive. Rust engine calls release the GIL while they run; actual throughput still depends on executor size, CPU cores, and storage.
 
 ```python
 import asyncio
@@ -457,7 +458,7 @@ async def main():
     async with await AsyncDatabase.open("./mydb", dimension=1536, bits=4) as db:
         await db.insert("doc1", vec, document="...")
         results = await db.search(query, top_k=5)
-        # 50 concurrent searches — actually run in parallel:
+        # Concurrent searches fan out through the executor:
         all_results = await asyncio.gather(
             *(db.search(q, top_k=5) for q in queries)
         )
@@ -567,6 +568,8 @@ print(col.peek(limit=3))    # dict same shape as query result
 
 **Metric mapping:** `metadata={"hnsw:space": "cosine"}` → `metric="cosine"`, `"ip"` → inner product (default), `"l2"` → L2. The metric is fixed at collection creation and cannot be changed.
 
+**Empty behavior:** `get(ids=[])` returns an empty Chroma-shaped response, not a full-table scan. `query(...)` on an empty collection returns one empty result row per query embedding. `add(ids=[], embeddings=[])` raises `ValueError` because Chroma-compatible adds require at least one embedding to validate or establish dimension.
+
 **Not implemented:** `HttpClient`, `Settings`, server/cloud mode, `chromadb.Client()` (ephemeral), `where_document` filtering, automatic text embedding (pass pre-computed `embeddings`; or provide an `embedding_function` callable at collection creation time).
 
 **Where-filter operators supported:** `$eq`, `$ne`, `$gt`, `$gte`, `$lt`, `$lte`, `$in`, `$nin`, `$and`, `$or`, `$exists`, `$contains`.
@@ -605,7 +608,11 @@ tbl.optimize()   # no-op; tqdb handles compaction automatically
 
 **SQL WHERE parser:** supports `field = 'value'`, `field != 'value'`, `field IN ('a', 'b', ...)` (including `id IN (...)`), and numeric comparisons (`field > 10`, `field >= 10`, `field < 10`, `field <= 10`). More complex predicates raise `NotImplementedError`.
 
-**Not implemented:** `update(where, values)`, `merge_insert()`, `create_fts_index`, `create_scalar_index`, `drop_database`, remote/cloud URIs.
+**Empty behavior:** a table without a manifest reports `count_rows()==0`; `head()`, `to_arrow()`, `to_pandas()`, and searches with no matches return empty tables/lists rather than raising. `add([])` and `add(empty_pyarrow_table)` are always no-ops; they do not create a manifest or establish a brand-new table's schema.
+
+**Implemented compatibility subset:** `update(where, values)` and `merge_insert(on).when_matched_update_all().when_not_matched_insert_all().execute(data)` are supported for basic upsert/update workflows. Other merge clauses are accepted as no-ops.
+
+**Not implemented:** `create_fts_index`, `create_scalar_index`, `drop_database`, remote/cloud URIs.
 
 ---
 

--- a/docs/QUANTIZER_MODES.md
+++ b/docs/QUANTIZER_MODES.md
@@ -1,134 +1,149 @@
-# Quantizer Modes: SRHT vs. Dense
+# Quantizer Modes: SRHT vs Dense Haar QR
 
-TurboQuantDB supports two quantizer families, selected via `quantizer_type` when opening a
-database. Both use the same MSE (Lloyd-Max) codebook and produce identical on-disk code
+TurboQuantDB supports two quantizer families, selected via `quantizer_type` when opening
+a database. Both use the same Lloyd-Max codebook and produce identical on-disk *code*
 layouts — the only difference is the rotation applied before quantization.
 
 ```python
-db = Database.open(path, dimension=DIM, bits=4)                           # default = dense
-db = Database.open(path, dimension=DIM, bits=4, quantizer_type="dense")   # explicit dense
-db = Database.open(path, dimension=DIM, bits=4, quantizer_type="srht")    # fast-ingest path
+db = Database.open(path, dimension=DIM, bits=4)                           # auto: dense if d<1024, srht if d>=1024
+db = Database.open(path, dimension=DIM, bits=4, quantizer_type="dense")   # force dense
+db = Database.open(path, dimension=DIM, bits=4, quantizer_type="srht")    # force srht
 # "exact" is accepted as a backward-compatible alias for "dense"
 ```
 
----
+## Default at a glance
 
-## What Each Mode Does
+| Dimension | Default | Why |
+|---|---|---|
+| `d < 1024` | `"dense"` | SRHT's pow2-padding tax outweighs its rotation-matrix savings; dense is competitive on every axis. |
+| `d >= 1024` | `"srht"` | SRHT delivers 2–3× ingest speedup, 1.5–3× lower p50, equal or slightly better recall, and lower RAM. The pow2-padding overhead becomes acceptable relative to total disk. |
 
-### `"srht"`
+The threshold is conservative — at d ≈ 768 SRHT already wins on most axes. If you
+care about ingest throughput at d=768 or below, override with `quantizer_type="srht"`
+explicitly.
 
-Applies a **Structured Random Hadamard Transform**: a random diagonal sign-flip matrix `D`
-followed by the Walsh-Hadamard transform `H`. Zero-pads the input to the next power of two
-so `n = next_power_of_two(d)`.
+## What each mode does
+
+### `"srht"` — Structured Random Hadamard Transform
+
+Applies a random diagonal sign-flip matrix `D` followed by the Walsh–Hadamard transform
+`H`. Zero-pads the input to the next power of two so `n = next_power_of_two(d)`.
 
 - Rotation cost: O(d log d) per vector
-- Rotation state: a random sign vector — O(d) storage, O(d) RAM
+- Rotation state on disk: a length-n random sign vector — **negligible**
 - Subspace count (b=4): `n / 8 = next_power_of_two(d) / 8`
 
-### `"dense"` (default)
+### `"dense"` — Haar-uniform QR rotation
 
-Applies a **Haar-uniform QR rotation**: samples a random Gaussian matrix and takes its QR
-factorization to get a Haar-distributed orthogonal matrix. No zero-padding: `n = d`.
+Samples a random Gaussian d×d matrix and takes its QR factorization to get a
+Haar-distributed orthogonal matrix. No zero-padding: `n = d`.
 
 - Rotation cost: O(d²) per vector (dense d×d matrix-vector multiply)
-- Rotation state: full d×d float32 matrix — O(d²) storage and RAM
+- Rotation state on disk: full d×d matrix stored as **bfloat16** (since v0.9) — `d² × 2` bytes
 - Subspace count (b=4): `d / 8`
 
----
+> The rotation matrix is bf16 on disk but rehydrated to f32 in memory at load time, so
+> the rotation hot path is unchanged. Recall is unchanged within sample noise (verified
+> on GloVe d=200 b=4 rerank=F at 10k queries: ΔR@1 = +0.0002).
 
-## Resource Comparison
+## Resource comparison
 
-### CPU
+### Ingest throughput
 
-| Operation | SRHT | Dense | Notes |
-|-----------|------|-------|-------|
-| Ingest per vector | O(d log d) | O(d²) | Dense is ~140× more ops at d=1536 |
-| DB open (init) | Negligible | O(d²) one-time QR | Paid once at first `Database.open()` |
-| Search scoring per vector | `n/8` subspaces | `d/8` subspaces | Dense is ~25% fewer at d=1536 |
+Measured on Windows 11, Python 3.11, single-process, n=100k vectors:
 
-**Example at d=1536:** SRHT ingest ≈ 16k multiply-adds per vector; Dense ≈ 2.4M. In
-practice the dense mat-vec is BLAS-optimized (cache-friendly), so the wall-clock ratio is
-10–30× rather than 140×, but still significant for large collections.
+| dim | dense (vps) | srht (vps) | speedup |
+|---:|---:|---:|---:|
+| 200 | 54,577 | 59,891 | 1.1× |
+| 1536 | 6,361 | 12,207 | **1.9×** |
+| 3072 | 2,140 | 6,348 | **3.0×** |
 
-### Memory (RAM)
+Below d=512 the speedup is in the noise; from d=1024 it grows quickly because the
+dense `d²` rotation becomes the bottleneck.
 
-| Component | SRHT | Dense |
-|-----------|------|-------|
-| Rotation matrix | ~0 (seed only) | d² × 4 bytes — **18.9 MB at d=1536, 75.5 MB at d=3072** |
-| `live_codes.bin` (mmap) | `n × b/8` B/vec, n padded | `d × b/8` B/vec — **~25% less** |
-| MSE codebook | 256 centroids × `n/8` subspaces | 256 × `d/8` — smaller |
-| `live_vectors.bin` (rerank) | `d × 4` B/vec | Same |
+### Search latency (brute-force, b=4, rerank=False, 1k queries)
 
-At very high d (≥3072), the Dense rotation matrix (75.5 MB) can exceed the savings on
-codes — net RAM advantage shifts back to SRHT.
+| dim | dense p50 | srht p50 | dense p99 | srht p99 |
+|---:|---:|---:|---:|---:|
+| 200 | 1.15 ms | 1.30 ms | 1.48 ms | 1.81 ms |
+| 1536 | 7.44 ms | **6.02 ms** | 8.66 ms | **6.81 ms** |
+| 3072 | 19.14 ms | **10.74 ms** | 24.13 ms | **11.86 ms** |
+
+Dense scores fewer subspaces at low d (no padding), so p50 is competitive there. At
+d ≥ 1536 the per-vector rotation cost dominates and SRHT pulls ahead.
 
 ### Disk
 
-| File | SRHT | Dense |
-|------|------|-------|
-| `live_codes.bin` | ~33% larger (padding) | Smaller |
-| Rotation matrix (in `quantizer.bin`) | Negligible | 18.9 MB at d=1536 |
-| `live_vectors.bin` (rerank=True) | `d × 4` B/vec | Same |
+Two competing taxes:
 
-At d=1536, 100k vectors, `rerank=False` (codes only):
-- SRHT: ~103 MB (codes only)
-- Dense: ~78 MB (codes) + 19 MB (rotation matrix) ≈ **97 MB** — roughly similar total
+| Source | Dense | SRHT |
+|---|---|---|
+| Rotation state (`quantizer.bin`) | `d² × 2` bytes (bf16, **was f32 pre-v0.9**) | length-`n` sign vector — `~0` |
+| Code padding (`live_codes.bin`) | None — exact `d` slots | Pads `d → next_power_of_two(d)` codes |
 
-### Recall
+The padding tax matters at non-pow2 dims. At d=3072, b=4, n=100k:
 
-| Setting | SRHT | Dense |
-|---------|------|-------|
-| `fast_mode=True`, b=4 | Slightly lower | Marginally better |
-| `fast_mode=True`, b=2 | More visible gap | Better |
-| `fast_mode=False` | Similar | Similar |
+|  | code data | rotation matrix | total |
+|---|---:|---:|---:|
+| dense (bf16 rotation) | 153.6 MB | 18.0 MB | **171.6 MB** |
+| dense (f32 rotation, pre-v0.9) | 153.6 MB | 36.0 MB | 189.6 MB |
+| srht (pads d to 4096) | 204.8 MB | ~0 | 204.8 MB |
 
-The recall gap comes from zero-padding: SRHT allocates `b` bits across `n > d` dimensions,
-wasting some budget on the padded zeros. Dense uses exactly `d` dimensions so no bits are
-wasted. At b=4 the gap is small (< 1pp typically); at b=2 it is more noticeable.
+Dense wins disk at non-pow2 d once bf16 rotation is in. At pow2 dims (1024, 2048,
+4096) SRHT has no padding tax and wins disk.
 
----
+### RAM (delta during ingest, brute search)
 
-## Benchmark Summary (d=1536, 100k vectors, DBpedia OpenAI3, brute-force)
+| dim | dense | srht |
+|---:|---:|---:|
+| 200 | 15.7 MB | 18.2 MB |
+| 1536 | 169.5 MB | **126.2 MB** |
+| 3072 | 372.4 MB | **294.9 MB** |
 
-| Config | Recall@1 | Recall@4 | Ingest | p50 search | Disk |
-|--------|----------|----------|--------|------------|------|
-| SRHT b=4 rerank=F | ~96.2% | ~100% | ~70k vps | ~39ms | ~103 MB |
-| Dense b=4 rerank=F | ~96.8% | ~100% | ~5–8k vps | ~30ms | ~97 MB |
-| SRHT b=2 rerank=F | ~79.2% | ~99.7% | ~70k vps | ~39ms | ~59 MB |
-| Dense b=2 rerank=F | ~80.5% | ~99.8% | ~5–8k vps | ~30ms | ~48 MB |
+SRHT's RAM advantage at high d comes from the absent in-memory rotation matrix
+(36 MB at d=3072 even after bf16 disk encoding).
 
-*Ingest vps for Dense is heavily hardware-dependent (BLAS threadcount). Search p50 for
-Dense is faster because it scores fewer subspaces (192 vs 256 at d=1536).*
+### Recall (b=4, rerank=False, R@1)
 
----
+Measured on the public benchmark datasets, n=100k:
 
-## Decision Guide
+| dataset | dim | dense | srht | Δ (srht − dense) |
+|---|---:|---:|---:|---:|
+| GloVe-200 | 200 | 0.819 | **0.841** | +0.022 |
+| DBpedia-1536 | 1536 | 0.958 | **0.962** | +0.004 |
+| DBpedia-3072 | 3072 | 0.963 | **0.980** | +0.017 |
+
+SRHT meets or beats dense on R@1 at every measured dim. Earlier guidance suggesting
+SRHT loses recall was based on synthetic tests at low d; on the public datasets SRHT
+is at least as accurate.
+
+At b=2 the picture is similar: SRHT b=2 rerank=F R@1 ≈ 0.55 / 0.86 / 0.90 vs dense
+0.51 / 0.84 / 0.90 (d=200/1536/3072).
+
+## Decision guide
 
 | Scenario | Recommended |
-|----------|-------------|
-| Default / don't care | **Dense** — default, best recall, paper-faithful |
-| Frequent ingestion (streaming, live updates) at d ≥ 512 | **SRHT** — ingest is 10–30× faster |
-| Memory-constrained with very high d (≥ 3072) | **SRHT** — Dense rotation matrix costs 75 MB |
-| Maximum recall at low bit budget (b=2) | **Dense** — no wasted bits on padding |
-| Reproducing paper figures exactly | **Dense** — matches the paper's QR + Gaussian formulation |
-| One-time bulk load, heavy read workload | **Dense** (default) — 25% faster search |
+|---|---|
+| Default — let the auto-picker decide | `quantizer_type=None` (default) |
+| You're at d ≥ 1024 and care about ingest, latency, or RAM | `"srht"` (this is now the default) |
+| You're at d ≤ 768 and care about minimal disk overhead | `"dense"` (this is now the default) |
+| Reproducing paper figures exactly | `"dense"` (matches the QR + Gaussian formulation in the TurboQuant paper) |
+| Heavy frequent-ingestion workload at any d | `"srht"` |
+| Maximum recall at b=2 with `rerank=True` | Either — at b=2 with rerank the gap is well within 0.5 pp |
+| Recovering from format break in v0.9 | Old DBs with f32-stored rotation must be rebuilt; bf16 is bincode-incompatible with v0.8 |
 
----
+## ANN + rerank interaction
 
-## ANN + Rerank Interaction
+Both modes produce the same HNSW graph structure (indexed from the MSE codes) and the
+same rerank path (`live_vectors.bin` is identical). Their differences are confined to
+the pre-rerank candidate selection. With `rerank=True` and `rerank_precision="int8"`,
+the recall gap between modes is sub-0.5 pp at every measured cell.
 
-Both modes produce the same HNSW graph structure (indexed from the MSE codes). The rerank
-path reads `live_vectors.bin` (float32 originals), which is identical for both modes.
-The ANN recall difference between SRHT and Dense therefore comes only from the pre-rerank
-candidate selection quality, not from the rerank itself.
+## Backward compatibility
 
-For `rerank=True`, the recall gap between modes narrows further — the float32 rerank
-compensates for any coding error in candidate retrieval.
-
----
-
-## Backward Compatibility
-
-`quantizer_type="exact"` is accepted as an alias for `"dense"` and will continue to work
-in all future versions. Databases written with `quantizer_type="exact"` reopen correctly
-without any migration step — the `quantizer.bin` is format-identical.
+- `quantizer_type="exact"` remains an alias for `"dense"`.
+- Setting `quantizer_type="dense"` or `"srht"` explicitly always wins over the
+  auto-default — existing code paths are unaffected if you pass an explicit string.
+- **Format break in v0.9**: bf16 rotation storage is bincode-incompatible with v0.8.x
+  databases. Old databases must be rebuilt or migrated. SRHT-mode databases reopen
+  cleanly — only `dense` mode is affected.

--- a/docs/QUANTIZER_MODES.md
+++ b/docs/QUANTIZER_MODES.md
@@ -39,7 +39,7 @@ Samples a random Gaussian d×d matrix and takes its QR factorization to get a
 Haar-distributed orthogonal matrix. No zero-padding: `n = d`.
 
 - Rotation cost: O(d²) per vector (dense d×d matrix-vector multiply)
-- Rotation state on disk: full d×d matrix stored as **bfloat16** (since v0.9) — `d² × 2` bytes
+- Rotation state on disk: full d×d matrix stored as **bfloat16** — `d² × 2` bytes
 - Subspace count (b=4): `d / 8`
 
 > The rotation matrix is bf16 on disk but rehydrated to f32 in memory at load time, so
@@ -78,7 +78,7 @@ Two competing taxes:
 
 | Source | Dense | SRHT |
 |---|---|---|
-| Rotation state (`quantizer.bin`) | `d² × 2` bytes (bf16, **was f32 pre-v0.9**) | length-`n` sign vector — `~0` |
+| Rotation state (`quantizer.bin`) | `d² × 2` bytes (bf16, **was f32 in the earlier dense format**) | length-`n` sign vector — `~0` |
 | Code padding (`live_codes.bin`) | None — exact `d` slots | Pads `d → next_power_of_two(d)` codes |
 
 The padding tax matters at non-pow2 dims. At d=3072, b=4, n=100k:
@@ -86,7 +86,7 @@ The padding tax matters at non-pow2 dims. At d=3072, b=4, n=100k:
 |  | code data | rotation matrix | total |
 |---|---:|---:|---:|
 | dense (bf16 rotation) | 153.6 MB | 18.0 MB | **171.6 MB** |
-| dense (f32 rotation, pre-v0.9) | 153.6 MB | 36.0 MB | 189.6 MB |
+| dense (f32 rotation, earlier format) | 153.6 MB | 36.0 MB | 189.6 MB |
 | srht (pads d to 4096) | 204.8 MB | ~0 | 204.8 MB |
 
 Dense wins disk at non-pow2 d once bf16 rotation is in. At pow2 dims (1024, 2048,
@@ -130,7 +130,7 @@ At b=2 the picture is similar: SRHT b=2 rerank=F R@1 ≈ 0.55 / 0.86 / 0.90 vs d
 | Reproducing paper figures exactly | `"dense"` (matches the QR + Gaussian formulation in the TurboQuant paper) |
 | Heavy frequent-ingestion workload at any d | `"srht"` |
 | Maximum recall at b=2 with `rerank=True` | Either — at b=2 with rerank the gap is well within 0.5 pp |
-| Recovering from format break in v0.9 | Old DBs with f32-stored rotation must be rebuilt; bf16 is bincode-incompatible with v0.8 |
+| Recovering from the dense-format break | Old DBs with f32-stored rotation must be rebuilt; bf16 is bincode-incompatible with the earlier dense format |
 
 ## ANN + rerank interaction
 
@@ -144,6 +144,6 @@ the recall gap between modes is sub-0.5 pp at every measured cell.
 - `quantizer_type="exact"` remains an alias for `"dense"`.
 - Setting `quantizer_type="dense"` or `"srht"` explicitly always wins over the
   auto-default — existing code paths are unaffected if you pass an explicit string.
-- **Format break in v0.9**: bf16 rotation storage is bincode-incompatible with v0.8.x
+- **Dense-format break**: bf16 rotation storage is bincode-incompatible with earlier
   databases. Old databases must be rebuilt or migrated. SRHT-mode databases reopen
   cleanly — only `dense` mode is affected.

--- a/docs/SERVER_API.md
+++ b/docs/SERVER_API.md
@@ -2,11 +2,10 @@
 
 Optional Axum HTTP service providing TurboQuantDB in multi-tenant server mode. Use this when you need REST API access, multi-tenancy, authentication, quotas, or async job management. For single-process Python use, the embedded `tqdb` package is simpler.
 
-## v0.8 feature availability
+## Embedded feature availability
 
-The v0.8 sprint shipped five Python-side features. Most are **embedded-Python only**
-— they don't have HTTP equivalents on the server. Use the embedded `tqdb` package
-when you need them.
+Several Python-side features are **embedded-Python only** — they don't have HTTP
+equivalents on the server. Use the embedded `tqdb` package when you need them.
 
 | Feature | Embedded Python | HTTP server |
 |---|---|---|
@@ -17,14 +16,15 @@ when you need them.
 | Migration toolkit (`tqdb.migrate`, CLI) | yes | n/a — offline batch tool |
 | BM25 hybrid (`db.search(..., hybrid={...})`, v0.7) | yes | yes — `hybrid` field in `/query` request |
 
-Bridging integrations into server mode is a v0.9-or-later candidate; the embedded
-mode is canonical for those workflows today.
+Bridging integrations into server mode remains a future hardening item; the
+embedded mode is canonical for those workflows today.
 
 ## Installation
 
-The server binary ships pre-built inside the `tqdb` wheel on all supported platforms
-(Linux x86-64, macOS, Windows). **Linux arm64/aarch64** is the exception — see
-[Building from Source](#building-from-source-development-only) for that platform.
+The server binary ships pre-built inside the `tqdb` wheel on Linux x86-64,
+macOS, and Windows. **Linux arm64/aarch64** wheels do not bundle the server
+binary — see [Building from Source](#building-from-source-development-only) for
+that platform.
 
 ```bash
 pip install tqdb
@@ -42,7 +42,8 @@ launching to change the address, data directory, or other options (see
 
 ## Building from Source (development only)
 
-Linux arm64/aarch64 users and contributors building from the Git repo:
+Linux arm64/aarch64 users, source-distribution installs, and contributors
+building from the Git repo must build the server binary separately:
 
 ```bash
 cd server
@@ -58,6 +59,14 @@ Then launch the compiled binary:
 # Windows
 .\target\release\tqdb-server.exe
 ```
+
+The Python source distribution includes `server/Cargo.toml`, `server/Cargo.lock`,
+and `server/src/**`, but `pip install` from sdist does not build or bundle the
+server executable automatically. The `tqdb-server` console script first looks for
+`python/tqdb/_bin/tqdb-server*` in an installed wheel, then for
+`server/target/release/tqdb-server*` in a development checkout. If neither path
+exists, it prints the missing candidate paths and the `cd server && cargo build
+--release` command.
 
 ## Environment Variables
 

--- a/docs/WHAT_S_NEW_0_8.md
+++ b/docs/WHAT_S_NEW_0_8.md
@@ -29,7 +29,7 @@ hits = store.search(query_token_vectors_5x96, top_k=10)
 
 Each document holds N token vectors; queries are tokenized to K vectors and scored
 via MaxSim. Built as a Python-layer wrapper over `tqdb.Database` so it ships now;
-the v0.9 sprint will move it into the engine for tighter storage and native filter
+future engine work will move it into the core for tighter storage and native filter
 pushdown — **the public Python API stays the same**.
 
 Full guide: [`docs/MULTI_VECTOR.md`](MULTI_VECTOR.md).

--- a/docs/WHAT_S_NEW_0_8.md
+++ b/docs/WHAT_S_NEW_0_8.md
@@ -129,7 +129,7 @@ The new class implements the full LangChain `VectorStore` ABC, so calls like
 
 ## After v0.8
 
-The v0.9-v1.0 hardening work targets:
+The next hardening work targets:
 
 - **Native multi-vector engine integration** — replaces the Python-layer
   wrapper with `IdPool` doc-id grouping, an on-disk MaxSim kernel, and native
@@ -139,5 +139,5 @@ The v0.9-v1.0 hardening work targets:
 - Pre-1.0 hardening: `≥80%` test coverage, `.unwrap()` audit pass 2, API-key
   authentication baseline, complete `0.x → 1.0` migration guide.
 
-See the full [v0.9-v1.0 sprint board](https://github.com/users/jyunming/projects/3)
+See the full [hardening sprint board](https://github.com/users/jyunming/projects/3)
 for the running list.

--- a/docs/WHAT_S_NEW_0_8.md
+++ b/docs/WHAT_S_NEW_0_8.md
@@ -9,7 +9,7 @@ Five new Python-side features and **no breaking changes**:
 1. **Multi-vector / ColBERT** retrieval with MaxSim scoring.
 2. **LangChain v2** native `VectorStore` ABC.
 3. **LlamaIndex** native `BasePydanticVectorStore` integration.
-4. **`AsyncDatabase`** — asyncio facade with real concurrency (PyO3 releases the GIL).
+4. **`AsyncDatabase`** — asyncio facade that dispatches long-running calls through a thread-pool executor; Rust engine calls release the GIL while they run.
 5. **`tqdb.migrate`** — one-command import from existing Chroma / LanceDB collections.
 
 Existing v0.7 code keeps working. Upgrade is `pip install -U tqdb`.
@@ -71,13 +71,15 @@ from tqdb.aio import AsyncDatabase
 
 async with await AsyncDatabase.open("./mydb", dimension=1536) as db:
     await db.insert("doc1", vec)
-    # 50 concurrent searches — actually run in parallel:
+    # Concurrent searches fan out through the executor:
     all_results = await asyncio.gather(*(db.search(q, top_k=5) for q in queries))
 ```
 
-Thread-pool-backed wrapper over the sync `Database`. Because every PyO3 method
-already releases the GIL via `py.allow_threads`, concurrent `await` calls
-genuinely parallelise — the existing test suite includes a 50-task proof.
+Thread-pool-backed wrapper over the sync `Database`. Because Rust engine calls
+release the GIL while they run, concurrent awaits can proceed without blocking
+the event loop. Current tests verify executor fan-out with a blocking fake DB
+and event-loop responsiveness with a real DB; they are not a throughput
+benchmark.
 
 Full guide: [`docs/PYTHON_API.md` — Async API](PYTHON_API.md#async-api).
 
@@ -125,14 +127,14 @@ The new class implements the full LangChain `VectorStore` ABC, so calls like
 `store.add_documents(...)`, `store.similarity_search_with_score(...)`, and
 `store.from_texts(...)` work as documented in the LangChain reference.
 
-## What's coming in v0.9
+## After v0.8
 
-The v0.9-v1.0 hardening sprint targets:
+The v0.9-v1.0 hardening work targets:
 
-- **Native multi-vector engine integration** — replaces the v0.8 Python-layer
+- **Native multi-vector engine integration** — replaces the Python-layer
   wrapper with `IdPool` doc-id grouping, an on-disk MaxSim kernel, and native
   filter pushdown. Same public Python API, much tighter storage and faster search.
-- Server mode v0.8 feature parity (LangChain / LlamaIndex / multi-vector exposed
+- Server mode feature parity (LangChain / LlamaIndex / multi-vector exposed
   over HTTP) is a candidate but not yet committed.
 - Pre-1.0 hardening: `≥80%` test coverage, `.unwrap()` audit pass 2, API-key
   authentication baseline, complete `0.x → 1.0` migration guide.

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -15,7 +15,7 @@ module.
 
 ## Related guides
 
-These aren't strictly "integrations" but cover related v0.8 surfaces and live
+These aren't strictly "integrations" but cover related embedded surfaces and live
 one directory up:
 
 - **Multi-vector / ColBERT** — late-interaction retrieval with MaxSim scoring.

--- a/docs/research/non-padding-srht.md
+++ b/docs/research/non-padding-srht.md
@@ -1,0 +1,182 @@
+# Non-padding alternatives to SRHT — research note
+
+**Status:** investigation, not committed. Authored 2026-05-04 during the v0.9 quantizer
+sweep. Purpose: capture the design space for closing SRHT's pow2-padding disk tax at
+non-pow2 dimensions (1536, 3072 — the OpenAI/Cohere production embedding shapes).
+
+## Why this matters
+
+At d=1536 and d=3072, SRHT pads the input to the next power of two (2048, 4096) before
+applying the Walsh–Hadamard transform. The bench shows the practical impact:
+
+| dim | code data only | SRHT padded codes | padding overhead |
+|---:|---:|---:|---:|
+| 1536 | 38.4 MB (b=2) / 76.8 MB (b=4) | 51.2 MB / 102.4 MB | +33% |
+| 3072 | 76.8 MB / 153.6 MB | 102.4 MB / 204.8 MB | +33% |
+
+SRHT wins on every other axis (recall, ingest, p50, RAM) but pays this 33% disk tax
+at non-pow2 dims. If we can apply a structured pseudo-random orthogonal transform
+without padding, SRHT becomes Pareto-better than dense Haar QR everywhere.
+
+## Candidate approaches
+
+Ranked from most viable to least.
+
+### 1. DCT-II with random sign vector (DCT-RS) — most promising
+
+Apply `y = DCT-II(x ⊙ s)` where `s ∈ {±1}^d` is a random sign vector. DCT-II is a
+real orthogonal transform with an O(d log d) fast algorithm, defined for any length
+d (no padding). The random signs provide the JL-quality randomness; the DCT provides
+the structured mixing.
+
+**Pros**
+- No padding at any d
+- O(d log d) cost, comparable to SRHT
+- Real orthogonal — preserves inner products exactly modulo numerical precision
+- Well-studied in compressive sensing; concentration bounds match SRHT for `d × d → m`
+  random projections (Tropp 2011, Krahmer-Ward 2011)
+- Length-d sign vector is the only persistent state — disk overhead identical to SRHT
+
+**Cons**
+- Requires an FFT crate. Candidates: `rustfft` (mature, MIT licence), `realfft` (DCT
+  on top of `rustfft`)
+- DCT primitive is more expensive per-element than the Hadamard butterfly (real
+  multiplies vs sign flips), so per-vector wall-time is ~1.5–2× SRHT despite same
+  asymptotic order
+- Concentration is asymptotically equivalent to SRHT but the per-element variance has
+  a slightly different constant — may need a calibration pass to match recall
+
+**Implementation cost:** ~1 week. Add a new `quantizer_type="dct"` variant. Reuse the
+codebook + bit-packing path; only the rotation kernel changes.
+
+**Expected impact**
+- Disk: -25 to -50 MB at d=3072 b=4 (closes the 51 MB padding gap)
+- Ingest: ~80% of SRHT speed (still 1.5–2× faster than dense at d=3072)
+- Recall: equal to SRHT within 0.2 pp (theoretical concentration guarantees match)
+
+### 2. Block Hadamard with cross-block mixing permutation
+
+Decompose d into powers of two greedily (e.g. d=3072 = 2048+1024). Apply
+`H_2048` to the first block and `H_1024` to the second. To restore mixing across
+blocks, apply a random permutation π to the input *before* the block transforms and
+another permutation σ *after*. Final transform: `σ ∘ blockH ∘ π ∘ diag(s) ∘ x`.
+
+**Pros**
+- Reuses the existing Hadamard butterfly code (`src/linalg/hadamard.rs`)
+- Hadamard cost (sign-flip butterfly) is faster per-element than DCT
+- O(d log d) overall — sum of blocks
+- No new dependency
+
+**Cons**
+- Per-block mixing is exact JL; cross-block mixing comes only from the permutations,
+  which is weaker than full Hadamard
+- Concentration constant is worse than full Hadamard or DCT-RS; theoretical bound
+  loses a `log(num_blocks)` factor (Krahmer-Ward extension result)
+- For "awkward" d like 3072, the decomposition `2048 + 1024` has imbalanced blocks
+  → the smaller block dominates the per-coordinate variance
+- More implementation surface: permutation generation, block boundary management
+
+**Implementation cost:** ~2–3 days. Less disruptive than DCT but with a weaker
+guarantee.
+
+**Expected impact**
+- Disk: same as DCT (no padding)
+- Ingest: ~95% of SRHT speed (same butterfly, just smaller per block)
+- Recall: -0.5 to -1.5 pp vs full SRHT, maybe more at d where decomposition is unbalanced
+
+### 3. Truncated SRHT
+
+Pad to next pow2 `n`, apply full SRHT to length-n input, but only quantize and store
+the first `d` output coordinates. The remaining `n − d` coordinates are dropped.
+
+**Why this almost works:** all output coordinates of `H · D · (x, 0)` are linear
+combinations of the d non-zero input entries; no information is "in" the padding
+positions. So truncating outputs is a lossy projection but information-theoretically
+not catastrophic.
+
+**Why it's lossy:** the kept d coordinates aren't a uniform subset of an orthogonal
+basis — they're the first d rows of `H · D`, which are a *biased* subset. Variance
+of the remaining d-dim projection is no longer 1/d uniformly across coordinates,
+so the codebook's quantization noise is non-uniform, hurting recall.
+
+**Pros**
+- No new code beyond a slice on the output side
+- Removes the disk tax exactly (codes are length d, not n)
+
+**Cons**
+- Bias hurts recall — needs empirical measurement, but theoretical bound suggests
+  ~5–10 pp R@1 drop at b=4 (rough estimate from JL-with-row-sampling literature)
+- Probably not viable in practice; included for completeness
+
+**Implementation cost:** half a day.
+
+### 4. Subsampled circulant rotation
+
+Use a length-d random circulant matrix as the rotation. Circulant matrices have an
+O(d log d) FFT-based apply. Combined with a random diagonal sign matrix, gives a
+restricted-isometry-property–satisfying transform without padding (Romberg 2009).
+
+**Pros**
+- No padding
+- O(d log d) cost
+- Same FFT crate as DCT-RS (often subsumed)
+
+**Cons**
+- The full state is a length-d vector (the seed of the circulant) — same as DCT-RS,
+  no advantage
+- Not as well-tested in JL-projection settings as DCT-RS or block Hadamard
+- Higher implementation risk for marginal benefit over DCT-RS
+
+**Verdict:** dominated by DCT-RS. Skip.
+
+### 5. Generalized Hadamard at length 4k
+
+Hadamard matrices exist at all sizes that are multiples of 4 with the conjectured
+"Hadamard property" — not just powers of 2. The Paley construction provides
+`H_p` for any prime `p ≡ 3 (mod 4)`, plus tensor products (`H_{ab} = H_a ⊗ H_b`).
+
+For d=1536 = 2^9 × 3 = 512 × 3 → could use `H_512 ⊗ H_3`? But `H_3` doesn't exist
+(Hadamard's theorem requires multiples of 4). Doesn't easily apply to 1536 or 3072.
+
+For d=3072 = 1024 × 3, same issue.
+
+**Verdict:** elegant in theory, doesn't fit the dimensions of interest. Skip.
+
+## Recommendation
+
+Pursue **DCT-RS (option 1)** as a third `quantizer_type` value (e.g. `"dct"` or
+`"srht_nopad"`). It is:
+
+- Well-studied with strong concentration guarantees
+- O(d log d) without padding
+- A clean drop-in replacement for SRHT at non-pow2 dimensions
+
+Implementation steps (rough):
+1. Add `rustfft` (or `realfft`) to `Cargo.toml`
+2. New variant `MseQuantizer::new_dct(d, b, seed)` mirroring `new_srht` but using a
+   length-d sign vector and DCT-II for the rotation kernel
+3. Update auto-default: at d ≥ 1024, prefer DCT-RS over SRHT when d is not a power
+   of two; keep SRHT when d is a power of two (no padding tax there)
+4. Bench at d=1536, 3072 to verify recall parity
+5. Document in `QUANTIZER_MODES.md`
+
+**Skip block Hadamard** unless adding an FFT dependency is unacceptable. The recall
+penalty is real and not easily bounded.
+
+**Skip truncated SRHT** — likely too lossy.
+
+## Open questions
+
+- Is `rustfft` audit-clean and small-binary-impact? It pulls in `num-complex` and
+  has historically required SIMD-feature-flag care on Windows ARM64.
+- Does FAISS's IVF-PQ implementation use a similar trick? Worth checking — they
+  handle non-pow2 dim and report similar recall to padded SRHT.
+- For very high d (≥8192) the DCT primitive's per-element constant matters more.
+  Worth measuring crossover where dense Haar QR with bf16 rotation is still
+  competitive on disk despite the d² state cost.
+
+## Decision deferred
+
+This is a v0.10+ candidate. v0.9 ships SRHT default at d ≥ 1024 and bf16 rotation
+storage; non-padding SRHT is a follow-up if the padding tax actually bothers users
+in practice.

--- a/docs/research/non-padding-srht.md
+++ b/docs/research/non-padding-srht.md
@@ -1,6 +1,6 @@
 # Non-padding alternatives to SRHT — research note
 
-**Status:** investigation, not committed. Authored 2026-05-04 during the v0.9 quantizer
+**Status:** investigation, not committed. Authored 2026-05-04 during the quantizer
 sweep. Purpose: capture the design space for closing SRHT's pow2-padding disk tax at
 non-pow2 dimensions (1536, 3072 — the OpenAI/Cohere production embedding shapes).
 
@@ -177,6 +177,6 @@ penalty is real and not easily bounded.
 
 ## Decision deferred
 
-This is a v0.10+ candidate. v0.9 ships SRHT default at d ≥ 1024 and bf16 rotation
-storage; non-padding SRHT is a follow-up if the padding tax actually bothers users
-in practice.
+This is a future candidate. The current quantizer work ships SRHT default at
+d >= 1024 and bf16 rotation storage; non-padding SRHT is a follow-up if the
+padding tax actually bothers users in practice.

--- a/docs/research/quantizer-default-recommendation.md
+++ b/docs/research/quantizer-default-recommendation.md
@@ -1,11 +1,11 @@
-# v0.9 quantizer-default recommendation memo
+# Quantizer-default recommendation memo
 
 **Audience:** maintainer  •  **Status:** for review  •  Written 2026-05-04
 
 This memo synthesises the quantizer head-to-head benchmarks run between
 2026-05-03 and 2026-05-04 to answer one question:
 
-> **Which quantizer should `tqdb.Database.open(...)` default to in v0.9, and
+> **Which quantizer should `tqdb.Database.open(...)` default to, and
 > when should users be steered off the default?**
 
 It covers tqdb's two internal modes (dense Haar QR, SRHT) plus four external
@@ -18,7 +18,7 @@ turborag, turbodb).
 
 1. **Ship SRHT as the default at d ≥ 1024**, dense Haar QR below. The threshold
    is chosen so SRHT's pow2-padding tax never exceeds the dense rotation-matrix
-   tax. This is implemented on `feat/v0.9-srht-default-and-bf16-rotation`.
+   tax. This is implemented on the current quantizer branch.
 
 2. **Ship bf16 storage for the dense Haar QR rotation matrix.** Halves
    `quantizer.bin` for dense (-18 MB at d=3072), recall verified unchanged at
@@ -31,7 +31,7 @@ turborag, turbodb).
    docs needed updating (done).
 
 4. **Defer non-padding SRHT** (DCT-RS variant) to v0.10+. Investigated; viable
-   but requires `rustfft` dependency and a new `quantizer_type` value. Tracked
+   but requires a `rustfft` dependency and a new `quantizer_type` value. Tracked
    in `docs/research/non-padding-srht.md`.
 
 ---
@@ -86,7 +86,7 @@ in exchange for 3× ingest, 2× p50, 21% less RAM, and +1.7 pp recall.
 At every d ≥ 1024, the dense Haar QR's per-vector matrix multiply dominates
 ingest. Going to SRHT's O(d log d) butterfly is a 2–3× ingest speedup with no
 recall cost (and at d=3072 actually a recall *win*). This compounds with the
-v0.9 bf16 storage of the dense rotation matrix — together they give users two
+bf16 storage of the dense rotation matrix — together they give users two
 disjoint paths:
 - Want best ingest + p50? Use SRHT (auto-default at d ≥ 1024).
 - Want absolute minimum disk? Use dense (which is now ~50% smaller on the
@@ -188,7 +188,7 @@ The bench used `max_degree=32, search_list_size=128`. snapvec IVFPQ uses
 structure. tqdb's HNSW recall at d=1536 is 0.912 with the same params — far
 better, suggesting the params are tuned for higher dim.
 
-**Concrete v0.9.1 follow-up:** dim-aware HNSW defaults. At d=200 the corpus
+**Concrete follow-up:** dim-aware HNSW defaults. At d=200 the corpus
 is small enough that brute is competitive (1.1 ms p50); HNSW only helps if
 recall is preserved. At d=1536+ HNSW gives 2× p50 win at -5 pp recall, which
 is a useful trade-off.
@@ -199,7 +199,7 @@ Tuning the defaults is enough.
 
 ---
 
-## What ships in v0.9 (this branch)
+## What ships in this branch
 
 | Change | Files | Status |
 |---|---|---|
@@ -210,18 +210,18 @@ Tuning the defaults is enough.
 | Updated PYTHON_API + README rerank framing | `docs/PYTHON_API.md`, `README.md` | ✓ committed |
 | Research note: non-padding SRHT (deferred) | `docs/research/non-padding-srht.md` | ✓ committed |
 
-Branch: `feat/v0.9-srht-default-and-bf16-rotation`. All 463 cargo unit tests
+All 463 cargo unit tests
 pass. Recall verified on GloVe-200 with 10k queries (ΔR@1 = +0.0002 for dense
 bf16 vs the prior f32 baseline).
 
 ## Open questions / follow-ups
 
-1. **Migration story for v0.8 → v0.9 dense DBs.** bf16 rotation breaks bincode
+1. **Migration story for dense DBs created before bf16 storage.** bf16 rotation breaks bincode
    compatibility for dense-mode DBs. SRHT-mode DBs are unaffected. Options:
    (a) ship a one-shot rebuild tool, (b) detect v0.8 manifest version and
    re-quantize on first open, (c) document the break and require manual rebuild.
-   Recommendation: (c) for v0.9 (clean break, pre-1.0 license), (b) as polish
-   for v0.10.
+   Recommendation: (c) for the current patch (clean break, pre-1.0 license),
+   (b) as later polish.
 
 2. **HNSW default param tuning.** At d=200 HNSW recall collapses to 0.46 with
    the bench params (`max_degree=32, search_list_size=128`). At d=1536 it's

--- a/docs/research/v0.9-quantizer-recommendation.md
+++ b/docs/research/v0.9-quantizer-recommendation.md
@@ -1,0 +1,212 @@
+# v0.9 quantizer-default recommendation memo
+
+**Audience:** maintainer  •  **Status:** for review  •  Written 2026-05-04
+
+This memo synthesises the quantizer head-to-head benchmarks run between
+2026-05-03 and 2026-05-04 to answer one question:
+
+> **Which quantizer should `tqdb.Database.open(...)` default to in v0.9, and
+> when should users be steered off the default?**
+
+It covers tqdb's two internal modes (dense Haar QR, SRHT) plus four external
+baselines (FAISS RaBitQ, snapvec SnapIndex/PQ/IVFPQ/Residual, turboqvec,
+turborag, turbodb).
+
+---
+
+## TL;DR
+
+1. **Ship SRHT as the default at d ≥ 1024**, dense Haar QR below. The threshold
+   is chosen so SRHT's pow2-padding tax never exceeds the dense rotation-matrix
+   tax. This is implemented on `feat/v0.9-srht-default-and-bf16-rotation`.
+
+2. **Ship bf16 storage for the dense Haar QR rotation matrix.** Halves
+   `quantizer.bin` for dense (-18 MB at d=3072), recall verified unchanged at
+   10k queries on GloVe-200 (ΔR@1 = +0.0002).
+
+3. **Reframe `rerank=False` as the production default in marketing copy.**
+   The compression-first story holds at d ≥ 1536 where rerank=F already gives
+   R@1 ≈ 0.96. The README/docs should lead with this and offer rerank as an
+   opt-in upgrade rather than the default. Code default already does this; only
+   docs needed updating (done).
+
+4. **Defer non-padding SRHT** (DCT-RS variant) to v0.10+. Investigated; viable
+   but requires `rustfft` dependency and a new `quantizer_type` value. Tracked
+   in `docs/research/non-padding-srht.md`.
+
+---
+
+## What we measured
+
+### Datasets
+- GloVe-200: 100k corpus, 1k queries, d=200
+- DBpedia-1536: 100k corpus, 1k queries, d=1536 (OpenAI ada-002)
+- DBpedia-3072: 100k corpus, 1k queries, d=3072 (OpenAI text-embed-3-large)
+
+### Engines & configs
+
+| Engine | Quantizer | b=2 | b=4 | rerank variants tested |
+|---|---|---|---|---|
+| tqdb | dense Haar QR | ✓ | ✓ | F, int8, residual_int4 |
+| tqdb | SRHT | ✓ | ✓ | F, int8, residual_int4 |
+| snapvec | SnapIndex (RHT, scalar) | ✓ | ✓ | — |
+| snapvec | ResidualSnapIndex | ✓ (b1=b2=2) | — | — |
+| snapvec | PQSnapIndex | M=d/4 | M=d/2 | — |
+| snapvec | IVFPQSnapIndex | — | M=d/2 | — |
+| turboqvec | PolarQuant Stage 1 | ✓ | ✓ | — |
+| turborag | rotation+Lloyd-Max | ✓ (Python kernel) | ✓ (Python kernel) | — |
+| turbodb | TurboQuant-py wrapper | — | — | abandoned: too slow |
+| FAISS | IndexRaBitQ | b=1 native | — | — |
+
+### Per-cell metric panel
+R@1, R@10, MRR, ingest_vps, fit_s (where applicable), disk_mb, compression×,
+RAM_Δ, RAM_query_peak, p50/p95/p99 ms.
+
+---
+
+## Findings, ranked by leverage
+
+### 1. SRHT beats dense at d ≥ 1024 across the board (except disk at non-pow2)
+
+| metric (b=4 rerank=F) | d=200 dense | d=200 srht | d=1536 dense | d=1536 srht | d=3072 dense | d=3072 srht |
+|---|---:|---:|---:|---:|---:|---:|
+| R@1 | 0.819 | **0.841** | 0.958 | **0.962** | 0.963 | **0.980** |
+| ingest vps | 54,577 | 59,891 | 6,361 | **12,207** | 2,140 | **6,348** |
+| p50 ms | **1.15** | 1.30 | 7.44 | **6.02** | 19.14 | **10.74** |
+| RAM Δ MB | **15.7** | 18.2 | 169.5 | **126.2** | 372.4 | **294.9** |
+| disk MB | **10.85** | 13.37 | **83.40** | 98.83 | **183.65** | 196.50 |
+
+Dense wins disk at non-pow2 d (because SRHT pads codes to pow2). Everywhere
+else SRHT is at-or-better. The disk gap is bounded: at d=3072 b=4 SRHT is
+12.85 MB larger than dense — a 7% increase relative to total disk. Acceptable
+in exchange for 3× ingest, 2× p50, 21% less RAM, and +1.7 pp recall.
+
+### 2. The rotation matrix is half the work
+
+At every d ≥ 1024, the dense Haar QR's per-vector matrix multiply dominates
+ingest. Going to SRHT's O(d log d) butterfly is a 2–3× ingest speedup with no
+recall cost (and at d=3072 actually a recall *win*). This compounds with the
+v0.9 bf16 storage of the dense rotation matrix — together they give users two
+disjoint paths:
+- Want best ingest + p50? Use SRHT (auto-default at d ≥ 1024).
+- Want absolute minimum disk? Use dense (which is now ~50% smaller on the
+  rotation tax due to bf16).
+
+### 3. PQ and IVFPQ are competitive but require training
+
+Snapvec PQ at M=d/2 ties SRHT on R@1 at d=200 (0.840 vs 0.841) at slightly
+better compression (7.08× vs 5.71×). Snapvec IVFPQ delivers **0.20 ms p50** at
+the cost of 14 pp recall. Both require a one-shot `fit()` (~75–145 s on
+GloVe-200, scales as O(N·K·iters·D)).
+
+For tqdb's "zero-training" pitch this is a fair trade-off to *not* match. The
+training step is a real burden for streaming/online ingestion, and tqdb's pitch
+is sharper without it. The honest framing in docs:
+
+> tqdb uses a fixed Lloyd-Max codebook (no training pass over your data). PQ
+> and IVF-PQ-style quantizers achieve marginally better compression at b=4 by
+> learning a codebook from your distribution, at the cost of a one-shot
+> training pass. We chose the no-training path; if you have a stable corpus
+> and care about every byte, snapvec PQSnapIndex is a reasonable alternative.
+
+### 4. RaBitQ (FAISS) is not viable at low dim
+
+R@1 = 0.324 at d=200 b=1 — collapses below useful retrieval quality. RaBitQ's
+asymptotic-optimal claim holds at high d but at d=200 the 1-bit budget is
+information-starved. We did not bench RaBitQ at d=1536/3072 due to time
+constraints; the academic literature suggests RaBitQ at high d hits R@1 ≈
+0.85–0.90, comparable to tqdb b=2 SRHT no-rerank (0.86–0.90). At b=4 with
+rerank tqdb dominates; at b=1 budget RaBitQ catches up. No urgent action
+needed.
+
+### 5. Snapvec ResidualSnapIndex is misadvertised
+
+Claims 4–8× compression "training-free" but in our test gives **1.53×
+compression** at b1=b2=2, with disk 49.87 MB at d=200 n=100k. Either we
+configured it wrong or it stores f32 metadata that defeats the residual
+saving. Worth a follow-up only if we want to refute their README's compression
+claims; not a tqdb action item.
+
+### 6. tqdb's IVF and HNSW already work — we don't need a new routing layer
+
+Routing-bench numbers (`max_degree=32, search_list_size=128, alpha=1.2` for HNSW,
+`n_clusters=128` for IVF, b=4 rerank=F):
+
+| dim | mode | p50 ms | R@1 | index_s |
+|---:|---|---:|---:|---:|
+| 200 | brute | 1.11 | 0.813 | — |
+| 200 | HNSW | **0.45** | 0.462 | 8.8 |
+| 200 | IVF nprobe=4 | 1.03 | 0.685 | 2.5 |
+| 200 | IVF nprobe=16 | 1.46 | 0.764 | 3.0 |
+| 1536 | brute | 7.59 | 0.958 | — |
+| 1536 | HNSW | **3.95** | 0.912 | 43.7 |
+| 1536 | IVF nprobe=16 | 7.60 | 0.932 | 25.5 |
+| 3072 | brute | 19.95 | 0.963 | — |
+| 3072 | HNSW | **9.08** | 0.917 | 58.6 |
+| 3072 | IVF nprobe=8 | 17.73 | 0.895 | 50.9 |
+
+Comparison points:
+- snapvec IVFPQ at d=200: 0.20 ms p50 / R@1=0.703 (5× faster than tqdb HNSW
+  but at -25 pp recall vs tqdb brute)
+- tqdb HNSW at d=200: 0.45 ms p50 / R@1=0.462 (2× faster than tqdb brute, but
+  recall collapses with the bench's HNSW params)
+
+**The recall collapse at d=200 HNSW is a parameter problem, not architectural.**
+The bench used `max_degree=32, search_list_size=128`. snapvec IVFPQ uses
+`nlist=128` with `nprobe=8`, which is a fundamentally different routing
+structure. tqdb's HNSW recall at d=1536 is 0.912 with the same params — far
+better, suggesting the params are tuned for higher dim.
+
+**Concrete v0.9.1 follow-up:** dim-aware HNSW defaults. At d=200 the corpus
+is small enough that brute is competitive (1.1 ms p50); HNSW only helps if
+recall is preserved. At d=1536+ HNSW gives 2× p50 win at -5 pp recall, which
+is a useful trade-off.
+
+**No new routing-layer architecture is needed.** tqdb already supports HNSW
+(`create_index()`) and IVF (`create_coarse_index()`); both exist and work.
+Tuning the defaults is enough.
+
+---
+
+## What ships in v0.9 (this branch)
+
+| Change | Files | Status |
+|---|---|---|
+| Auto-default `quantizer_type=None` → SRHT at d≥1024 | `src/storage/engine/mod.rs` | ✓ committed |
+| bf16 Haar QR rotation on disk | `src/quantizer/mse.rs` | ✓ committed |
+| Updated Python docstring | `src/python/mod.rs` | ✓ committed |
+| Rewritten quantizer guide with real numbers | `docs/QUANTIZER_MODES.md` | ✓ committed |
+| Updated PYTHON_API + README rerank framing | `docs/PYTHON_API.md`, `README.md` | ✓ committed |
+| Research note: non-padding SRHT (deferred) | `docs/research/non-padding-srht.md` | ✓ committed |
+
+Branch: `feat/v0.9-srht-default-and-bf16-rotation`. All 463 cargo unit tests
+pass. Recall verified on GloVe-200 with 10k queries (ΔR@1 = +0.0002 for dense
+bf16 vs the prior f32 baseline).
+
+## Open questions / follow-ups
+
+1. **Migration story for v0.8 → v0.9 dense DBs.** bf16 rotation breaks bincode
+   compatibility for dense-mode DBs. SRHT-mode DBs are unaffected. Options:
+   (a) ship a one-shot rebuild tool, (b) detect v0.8 manifest version and
+   re-quantize on first open, (c) document the break and require manual rebuild.
+   Recommendation: (c) for v0.9 (clean break, pre-1.0 license), (b) as polish
+   for v0.10.
+
+2. **HNSW default param tuning.** At d=200 HNSW recall collapses to 0.46 with
+   the bench params (`max_degree=32, search_list_size=128`). At d=1536 it's
+   0.91. The defaults are dim-blind; making them dim-aware would push the
+   sub-ms p50 case (small d) much closer to snapvec IVFPQ's 0.20 ms.
+
+3. **Public bench refresh.** `paper_recall_bench.py` runs with explicit
+   `quantizer_type` choices today; the current README tables are unaffected by
+   the auto-default change. After v0.9 ships, update README headline numbers
+   to reflect the SRHT default at d ≥ 1024 (which gives slightly better recall
+   *and* much faster ingest).
+
+4. **PQ as opt-in `quantizer_type="pq"`?** Marginal benefit over SRHT; would
+   add training-time burden inconsistent with the "zero training" pitch.
+   Recommendation: do not pursue.
+
+5. **DCT-RS for non-padding SRHT.** Tracked in
+   `docs/research/non-padding-srht.md`. Defer to v0.10+ unless padding tax is
+   a customer complaint.

--- a/docs/research/v0.9-quantizer-recommendation.md
+++ b/docs/research/v0.9-quantizer-recommendation.md
@@ -127,7 +127,38 @@ configured it wrong or it stores f32 metadata that defeats the residual
 saving. Worth a follow-up only if we want to refute their README's compression
 claims; not a tqdb action item.
 
-### 6. tqdb's IVF and HNSW already work — we don't need a new routing layer
+### 6. The rotation is doing real work (identity baseline)
+
+Question we answered: how much value does the rotation actually add? Identity
+baseline = pure Lloyd-Max scalar quantization on raw coordinates with no Haar
+QR or SRHT preprocess.
+
+| dim | b | identity R@1 | tqdb SRHT R@1 (rerank=F) | rotation lift |
+|---:|---:|---:|---:|---:|
+| 200 | 2 | 0.286 | 0.553 | **+27 pp** |
+| 200 | 4 | 0.296 | 0.841 | **+55 pp** |
+| 1536 | 2 | 0.769 | 0.862 | +9 pp |
+| 1536 | 4 | 0.775 | 0.962 | **+19 pp** |
+| 3072 | 2 | 0.805 | 0.902 | +10 pp |
+| 3072 | 4 | 0.831 | 0.980 | +15 pp |
+
+Two clean findings:
+
+- **The rotation is essential at low dim** (anisotropic data like GloVe-200).
+  Without it, b=4 barely improves on b=2 (R@1 0.296 vs 0.286) — the codebook
+  has no way to use the extra bits because the per-coordinate variance is
+  uneven.
+- **At high dim, OpenAI ada-002/text-embed-3-large embeddings are
+  surprisingly isotropic.** Identity quantization at d=3072 b=4 hits R@1=0.831,
+  comparable to tqdb b=2 with rotation. But the rotation still adds a
+  meaningful +15 pp at b=4. It is not redundant.
+
+**Verdict on `quantizer_type="identity"`: don't ship it.** Even on already-
+isotropic embeddings the rotation gives +9 to +19 pp R@1, which is too large
+to leave on the table for a "simpler" code path. The dense Haar QR / SRHT
+investment is justified.
+
+### 7. tqdb's IVF and HNSW already work — we don't need a new routing layer
 
 Routing-bench numbers (`max_degree=32, search_list_size=128, alpha=1.2` for HNSW,
 `n_clusters=128` for IVF, b=4 rerank=F):

--- a/docs/research/v0.9-quantizer-recommendation.md
+++ b/docs/research/v0.9-quantizer-recommendation.md
@@ -228,11 +228,10 @@ bf16 vs the prior f32 baseline).
    0.91. The defaults are dim-blind; making them dim-aware would push the
    sub-ms p50 case (small d) much closer to snapvec IVFPQ's 0.20 ms.
 
-3. **Public bench refresh.** `paper_recall_bench.py` runs with explicit
-   `quantizer_type` choices today; the current README tables are unaffected by
-   the auto-default change. After v0.9 ships, update README headline numbers
-   to reflect the SRHT default at d ≥ 1024 (which gives slightly better recall
-   *and* much faster ingest).
+3. **Public bench refresh.** `paper_recall_bench.py` now opens databases with
+   `quantizer_type=None`, so v0.9 benchmark runs exercise the auto-default:
+   dense below d=1024 and SRHT at d ≥ 1024. Refresh README headline numbers
+   from a clean tracked run before release.
 
 4. **PQ as opt-in `quantizer_type="pq"`?** Marginal benefit over SRHT; would
    add training-time burden inconsistent with the "zero training" pitch.

--- a/docs/research/v0.9-quantizer-recommendation.md
+++ b/docs/research/v0.9-quantizer-recommendation.md
@@ -229,7 +229,7 @@ bf16 vs the prior f32 baseline).
    sub-ms p50 case (small d) much closer to snapvec IVFPQ's 0.20 ms.
 
 3. **Public bench refresh.** `paper_recall_bench.py` now opens databases with
-   `quantizer_type=None`, so v0.9 benchmark runs exercise the auto-default:
+   `quantizer_type=None`, so benchmark runs exercise the auto-default:
    dense below d=1024 and SRHT at d ≥ 1024. Refresh README headline numbers
    from a clean tracked run before release.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,13 @@ Changelog = "https://github.com/jyunming/TurboQuantDB/releases"
 [tool.maturin]
 features = ["python", "pyo3/extension-module"]
 python-source = "python"
-include = ["python/tqdb/*.pyi", "python/tqdb/_bin/*"]
+include = [
+    "python/tqdb/*.pyi",
+    "python/tqdb/_bin/*",
+    { path = "server/Cargo.toml", format = "sdist" },
+    { path = "server/Cargo.lock", format = "sdist" },
+    { path = "server/src/**/*", format = "sdist" },
+]
 
 [tool.pytest.ini_options]
 tmp_path_retention_policy = "failed"

--- a/python/tqdb/chroma_compat.py
+++ b/python/tqdb/chroma_compat.py
@@ -77,6 +77,26 @@ _VALID_GET_INCLUDE = {"ids", "metadatas", "documents", "embeddings"}
 _VALID_QUERY_INCLUDE = {"ids", "metadatas", "documents", "embeddings", "distances"}
 
 
+def _empty_get_response(include_set: set[str]) -> Dict[str, Any]:
+    return {
+        "ids": [],
+        "metadatas": [] if "metadatas" in include_set else None,
+        "documents": [] if "documents" in include_set else None,
+        "embeddings": [] if "embeddings" in include_set else None,
+    }
+
+
+def _empty_query_response(include_set: set[str], n_queries: int) -> Dict[str, Any]:
+    rows = [[] for _ in range(n_queries)]
+    return {
+        "ids": rows,
+        "distances": [[] for _ in range(n_queries)] if "distances" in include_set else None,
+        "metadatas": [[] for _ in range(n_queries)] if "metadatas" in include_set else None,
+        "documents": [[] for _ in range(n_queries)] if "documents" in include_set else None,
+        "embeddings": [[] for _ in range(n_queries)] if "embeddings" in include_set else None,
+    }
+
+
 def _apply_filter(records: List[Dict[str, Any]], where: Dict[str, Any]) -> List[Dict[str, Any]]:
     """Very small subset of Chroma where-filter evaluation."""
     def _matches(metadata: Dict[str, Any], expr: Dict[str, Any]) -> bool:
@@ -429,6 +449,8 @@ class CompatCollection:
         where: Optional[Dict[str, Any]] = None,
     ) -> None:
         with self._write_lock:
+            if not os.path.exists(os.path.join(self._path, "manifest.json")):
+                return
             db = self._open_db(None)
             if ids and not where:
                 db.delete_batch(ids)
@@ -456,9 +478,9 @@ class CompatCollection:
             unknown = set(include) - _VALID_GET_INCLUDE
             if unknown:
                 raise ValueError(f"Unknown include fields: {unknown}. Valid: {_VALID_GET_INCLUDE}")
-        if not os.path.exists(os.path.join(self._path, "manifest.json")):
-            return {"ids": [], "metadatas": [], "documents": []}
         include_set = set(include or ["metadatas", "documents"])
+        if not os.path.exists(os.path.join(self._path, "manifest.json")):
+            return _empty_get_response(include_set)
         db = self._open_db(None)
 
         # BUG-C7: an explicitly-passed empty list means "return nothing";
@@ -510,6 +532,8 @@ class CompatCollection:
                 raise ValueError(f"Unknown include fields: {unknown}. Valid: {_VALID_QUERY_INCLUDE}")
         query_embeddings = self._embed(query_texts or [], query_embeddings)
         include_set = set(include or ["metadatas", "documents", "distances"])
+        if not os.path.exists(os.path.join(self._path, "manifest.json")):
+            return _empty_query_response(include_set, len(query_embeddings))
         db = self._open_db(None)
 
         all_ids, all_distances, all_metas, all_docs, all_embeddings = [], [], [], [], []

--- a/python/tqdb/lancedb_compat.py
+++ b/python/tqdb/lancedb_compat.py
@@ -84,7 +84,7 @@ _FIELD_NEQ_STR_PATTERN = re.compile(
     r"""^\s*(\w+)\s*!=\s*'([^']*)'\s*$"""
 )
 _FIELD_EQ_NUM_PATTERN = re.compile(
-    r"""^\s*(\w+)\s*=\s*(\d+(?:\.\d+)?)\s*$"""
+    r"""^\s*(\w+)\s*=\s*(-?\d+(?:\.\d+)?)\s*$"""
 )
 _FIELD_CMP_PATTERN = re.compile(
     r"""^\s*(\w+)\s*(>=|<=|>|<)\s*(-?\d+(?:\.\d+)?)\s*$"""
@@ -343,6 +343,8 @@ class CompatQuery:
         return self
 
     def to_list(self) -> List[Dict[str, Any]]:
+        if self._k == 0:
+            return []
         tqdb_filter: Optional[Dict[str, Any]] = None
         id_allowset: Optional[set] = None
         if self._where:
@@ -352,6 +354,9 @@ class CompatQuery:
                 id_allowset = set(id_cond["$in"])
             else:
                 tqdb_filter = parsed
+
+        if not os.path.exists(os.path.join(self._table._path, "manifest.json")):
+            return []
 
         # Full-table scan when query is None
         if self._query is None:

--- a/python/tqdb/multivector.py
+++ b/python/tqdb/multivector.py
@@ -10,7 +10,7 @@ This module is a **Python-layer wrapper** over the existing single-vector
 TQDB; a JSON sidecar tracks the ``doc_id → [token_id, ...]`` mapping, and a
 ``_VecStore`` keeps raw float32 token vectors for exact MaxSim scoring.
 
-Future v0.9 release will move multi-vector into the engine for tighter
+Future engine work will move multi-vector into the core for tighter
 storage and native filter pushdown — this module's public API is designed
 to stay stable across that move.
 

--- a/python/tqdb/multivector.py
+++ b/python/tqdb/multivector.py
@@ -289,6 +289,12 @@ class MultiVectorStore:
         n = vectors.shape[0]
         if n == 0:
             raise ValueError("must provide at least one token vector per doc")
+        expected_dim = self._db.stats().get("dimension")
+        if expected_dim is not None and vectors.shape[1] != expected_dim:
+            raise ValueError(
+                f"vector dimension mismatch: expected {expected_dim}, got "
+                f"{vectors.shape[1]}"
+            )
 
         # Replace semantics: drop stale token IDs first.
         old = self._index.remove(doc_id)

--- a/scripts/ci/run_recall_bench.py
+++ b/scripts/ci/run_recall_bench.py
@@ -300,7 +300,7 @@ def run_benchmark(args):
             f"FAIL: Recall@{args.k} = {recall_at_k:.1%} "
             f"(threshold: {args.recall_threshold:.0%})"
         )
-        print(f"✓ Recall threshold passed (≥{args.recall_threshold:.0%})")
+        print(f"OK Recall threshold passed (>={args.recall_threshold:.0%})")
 
     return result
 

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1678,7 +1678,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tqdb"
-version = "0.8.1"
+version = "0.8.3"
 dependencies = [
  "bincode",
  "crc32fast",

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -59,12 +59,18 @@ impl Database {
     ///         that already emit unit vectors can set this to avoid repeating the normalisation
     ///         themselves.  Default ``False``.
     ///     quantizer_type: Which quantizer rotation to use:
-    ///         - ``None`` / ``"dense"`` (default): Haar-uniform QR rotation + dense Gaussian
-    ///           projection. n=d (no padding). Best recall; O(d²) ingest cost.
-    ///           ``"exact"`` is accepted as a legacy alias.
-    ///         - ``"srht"``: structured Walsh-Hadamard rotation. n=next_power_of_two(d).
-    ///           O(d log d) ingest; ~25% more subspaces scored at search time.
-    ///           Use for streaming or frequent-ingest workloads at high d.
+    ///         - ``None`` (default): auto-select. ``"dense"`` for ``d < 1024``,
+    ///           ``"srht"`` for ``d >= 1024``. The crossover reflects empirical
+    ///           wins for SRHT on ingest, p50, and (slightly) recall once the
+    ///           rotation is the dominant cost. To force a specific mode set the
+    ///           string explicitly.
+    ///         - ``"dense"``: Haar-uniform QR rotation + dense Gaussian
+    ///           projection. n=d (no padding). O(d²) ingest cost; stores a
+    ///           d×d f32 matrix on disk. ``"exact"`` is accepted as a legacy
+    ///           alias.
+    ///         - ``"srht"``: structured Walsh-Hadamard rotation. n=next
+    ///           power-of-two of d. O(d log d) ingest; pads to the next pow2
+    ///           in storage at non-pow2 d.
     ///         See `docs/QUANTIZER_MODES.md` for a full CPU/RAM/disk/recall comparison.
     ///
     /// Returns:

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -66,8 +66,8 @@ impl Database {
     ///           string explicitly.
     ///         - ``"dense"``: Haar-uniform QR rotation + dense Gaussian
     ///           projection. n=d (no padding). O(d²) ingest cost; stores a
-    ///           d×d f32 matrix on disk. ``"exact"`` is accepted as a legacy
-    ///           alias.
+    ///           d×d rotation matrix as bf16 on disk and rehydrates it to f32
+    ///           on load. ``"exact"`` is accepted as a legacy alias.
     ///         - ``"srht"``: structured Walsh-Hadamard rotation. n=next
     ///           power-of-two of d. O(d log d) ingest; pads to the next pow2
     ///           in storage at non-pow2 d.

--- a/src/quantizer/mse.rs
+++ b/src/quantizer/mse.rs
@@ -70,8 +70,56 @@ pub struct MseQuantizer {
     pub centroids: Vec<f32>,
     /// Exact-paper mode: d×d Haar-random orthogonal matrix, row-major.
     /// `None` → use SRHT (default). `Some` → dense matrix-vector multiply.
-    #[serde(default)]
+    ///
+    /// On disk this is encoded as bfloat16 (truncated f32 high bits) — about
+    /// 3 bits of mantissa loss per element relative to f32. For an orthogonal
+    /// matrix with elements ~N(0, 1/d) this loss is well below the Lloyd-Max
+    /// codebook quantization noise floor, so recall is unchanged at the
+    /// measurement precision of the public benchmarks. In memory the matrix
+    /// is rehydrated to f32 so the rotation hot-path is unchanged.
+    #[serde(default, with = "bf16_option_vec")]
     pub rotation_matrix: Option<Vec<f32>>,
+}
+
+/// Serde adapter: serialize `Option<Vec<f32>>` as `Option<Vec<u16>>` where each
+/// `u16` holds the high 16 bits of an `f32` (bfloat16 with round-to-nearest).
+/// On deserialization the f32 is reconstructed by left-shifting back into the
+/// high half of the f32 bits — the low mantissa bits are zero.
+mod bf16_option_vec {
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    fn f32_to_bf16(x: f32) -> u16 {
+        // Round-to-nearest-even: add 0x7FFF + (low_bit) to the bits, then truncate.
+        let bits = x.to_bits();
+        let low_bit = (bits >> 16) & 1;
+        let rounded = bits.wrapping_add(0x7FFF + low_bit);
+        (rounded >> 16) as u16
+    }
+
+    fn bf16_to_f32(b: u16) -> f32 {
+        f32::from_bits((b as u32) << 16)
+    }
+
+    pub fn serialize<S>(v: &Option<Vec<f32>>, s: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match v {
+            None => Option::<Vec<u16>>::None.serialize(s),
+            Some(v) => {
+                let packed: Vec<u16> = v.iter().map(|&f| f32_to_bf16(f)).collect();
+                Some(packed).serialize(s)
+            }
+        }
+    }
+
+    pub fn deserialize<'de, D>(d: D) -> Result<Option<Vec<f32>>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let opt: Option<Vec<u16>> = Option::deserialize(d)?;
+        Ok(opt.map(|v| v.iter().map(|&b| bf16_to_f32(b)).collect()))
+    }
 }
 
 impl MseQuantizer {

--- a/src/quantizer/mse.rs
+++ b/src/quantizer/mse.rs
@@ -510,6 +510,39 @@ mod tests {
         }
     }
 
+    #[test]
+    fn serde_preserves_srht_rotation_matrix_none() {
+        let q = MseQuantizer::new(32, 4, 42);
+        assert!(q.rotation_matrix.is_none());
+
+        let bytes = bincode::serialize(&q).unwrap();
+        let decoded: MseQuantizer = bincode::deserialize(&bytes).unwrap();
+
+        assert!(decoded.rotation_matrix.is_none());
+        assert_eq!(decoded.d, q.d);
+        assert_eq!(decoded.n, q.n);
+        assert_eq!(decoded.rotation_signs, q.rotation_signs);
+    }
+
+    #[test]
+    fn serde_roundtrips_dense_rotation_matrix_as_bf16() {
+        let q = MseQuantizer::new_dense(8, 4, 42);
+        let original = q.rotation_matrix.as_ref().unwrap().clone();
+
+        let bytes = bincode::serialize(&q).unwrap();
+        let decoded: MseQuantizer = bincode::deserialize(&bytes).unwrap();
+        let restored = decoded.rotation_matrix.as_ref().unwrap();
+
+        assert_eq!(restored.len(), original.len());
+        for (i, (&before, &after)) in original.iter().zip(restored.iter()).enumerate() {
+            let err = (before - after).abs();
+            assert!(
+                err <= 0.005,
+                "bf16 rotation roundtrip error too high at {i}: {before} vs {after}"
+            );
+        }
+    }
+
     /// C4 (v0.8.2 audit): b=1 produces 2 centroids and quantize/dequantize is
     /// stable (no panic, finite output). The 1-bit path is rarely exercised
     /// in production but is supported.

--- a/src/quantizer/prod.rs
+++ b/src/quantizer/prod.rs
@@ -136,6 +136,25 @@ impl ProdQuantizer {
         }
     }
 
+    fn packed_mse_len(&self) -> usize {
+        (self.n * self.mse_bits_per_idx()).div_ceil(8)
+    }
+
+    fn qjl_len(&self) -> usize {
+        self.n.div_ceil(8)
+    }
+
+    fn assert_qjl_len_if_used(&self, qjl: &[u8], gamma: f64, caller: &str) {
+        if gamma != 0.0 {
+            assert_eq!(
+                qjl.len(),
+                self.qjl_len(),
+                "{caller}: qjl.len() must equal ceil(n/8) ({}) when gamma is non-zero",
+                self.qjl_len()
+            );
+        }
+    }
+
     pub fn prepare_ip_query(&self, query: &Array1<f64>) -> PreparedIpQuery {
         assert_eq!(query.len(), self.d);
 
@@ -217,14 +236,20 @@ impl ProdQuantizer {
     /// which returns a centred value in [−1, 1].  Used as a proxy for inner-product
     /// proximity during HNSW construction when raw vectors are unavailable.
     pub fn hamming_proximity(&self, from_qjl: &[u8], to_qjl: &[u8]) -> f64 {
-        let n_bytes = from_qjl.len().min(to_qjl.len());
-        if n_bytes == 0 {
+        let n_bits = self.n.min(from_qjl.len().min(to_qjl.len()) * 8);
+        if n_bits == 0 {
             return 0.5;
         }
-        let matching_bits: u32 = (0..n_bytes)
+        let full_bytes = n_bits / 8;
+        let mut matching_bits: u32 = (0..full_bytes)
             .map(|i| (!(from_qjl[i] ^ to_qjl[i])).count_ones())
             .sum();
-        matching_bits as f64 / (n_bytes as f64 * 8.0)
+        let rem_bits = n_bits % 8;
+        if rem_bits > 0 {
+            let mask = (1u8 << rem_bits) - 1;
+            matching_bits += (!(from_qjl[full_bytes] ^ to_qjl[full_bytes]) & mask).count_ones();
+        }
+        matching_bits as f64 / n_bits as f64
     }
 
     /// Build a `PreparedIpQueryLite` directly from stored MSE codes without any SRHT.
@@ -257,6 +282,7 @@ impl ProdQuantizer {
             "score_ip_encoded_lite: idx.len() must equal quantizer.n ({})",
             self.n
         );
+        self.assert_qjl_len_if_used(qjl, gamma, "score_ip_encoded_lite");
         #[cfg(target_arch = "x86_64")]
         {
             if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
@@ -428,6 +454,7 @@ impl ProdQuantizer {
             "score_ip_encoded: idx.len() must equal quantizer.n ({})",
             self.n
         );
+        self.assert_qjl_len_if_used(qjl, gamma, "score_ip_encoded");
         #[cfg(target_arch = "x86_64")]
         {
             if is_x86_feature_detected!("avx2") && is_x86_feature_detected!("fma") {
@@ -585,16 +612,17 @@ impl ProdQuantizer {
         qjl: &[u8],
         gamma: f64,
     ) -> f64 {
-        let b = self.mse_quantizer.b;
-        debug_assert_eq!(
+        assert_eq!(
             packed_mse.len(),
-            (self.n * b).div_ceil(8),
+            self.packed_mse_len(),
             "score_ip_encoded_packed: packed_mse.len() must equal ceil(n*b/8) ({})",
-            (self.n * b).div_ceil(8)
+            self.packed_mse_len()
         );
+        self.assert_qjl_len_if_used(qjl, gamma, "score_ip_encoded_packed");
 
         #[cfg(target_arch = "x86_64")]
         {
+            let b = self.mse_quantizer.b;
             if (1..=8).contains(&b)
                 && is_x86_feature_detected!("avx2")
                 && is_x86_feature_detected!("fma")
@@ -839,6 +867,13 @@ impl ProdQuantizer {
     }
 
     pub fn quantize_batch(&self, xs: &[&[f32]]) -> Vec<(Vec<CodeIndex>, Vec<u8>, f64)> {
+        for x in xs {
+            assert_eq!(
+                x.len(),
+                self.d,
+                "quantize_batch: vector length must equal d"
+            );
+        }
         // Dense mode: batch all rotations via a single GEMM (Y = R × X) instead of
         // B separate matrix-vector multiplies. Break-even at B ≥ 64.
         const DENSE_BATCH_MIN: usize = 64;
@@ -976,6 +1011,12 @@ impl ProdQuantizer {
     }
 
     pub fn pack_mse_indices(&self, indices: &[CodeIndex]) -> Vec<u8> {
+        assert_eq!(
+            indices.len(),
+            self.n,
+            "pack_mse_indices: indices.len() must equal quantizer.n ({})",
+            self.n
+        );
         let bits_per_idx = self.mse_quantizer.b;
         if bits_per_idx == 8 {
             return indices.iter().map(|v| *v as u8).collect();
@@ -998,6 +1039,17 @@ impl ProdQuantizer {
     }
 
     pub fn unpack_mse_indices(&self, packed: &[u8], out: &mut [CodeIndex]) {
+        assert_eq!(
+            packed.len(),
+            self.packed_mse_len(),
+            "unpack_mse_indices: packed.len() must equal ceil(n*b/8) ({})",
+            self.packed_mse_len()
+        );
+        assert!(
+            out.len() >= self.n,
+            "unpack_mse_indices: out.len() must be at least quantizer.n ({})",
+            self.n
+        );
         #[cfg(target_arch = "x86_64")]
         if is_x86_feature_detected!("avx2") {
             return unsafe { self.unpack_mse_indices_avx2(packed, out) };
@@ -1151,7 +1203,7 @@ pub fn hamming_disagree_b4_signs(query_signs: &[u8], mse_bytes: &[u8]) -> u32 {
 /// Lower return = closer in IP.
 #[inline]
 pub fn hamming_disagree_signs<const B: usize>(query_signs: &[u8], mse_bytes: &[u8]) -> u32 {
-    debug_assert_eq!(
+    assert_eq!(
         query_signs.len() * B,
         mse_bytes.len(),
         "hamming_disagree_signs<B={B}>: query_signs.len()*B must equal mse_bytes.len()"
@@ -2306,6 +2358,77 @@ mod tests {
         let qjl_len = (pq.n + 7) / 8;
         let qjl = vec![0u8; qjl_len];
         let _ = pq.score_ip_encoded_lite(&prep, &short_idx, &qjl, 0.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "packed_mse.len() must equal ceil(n*b/8)")]
+    fn score_ip_encoded_packed_panics_on_short_packed_mse() {
+        let pq = make_pq(64);
+        let q: Array1<f64> = Array1::from_elem(64, 0.1);
+        let prep = pq.prepare_ip_query(&q);
+        let x = vec![0.2f32; 64];
+        let (idx, qjl, gamma) = pq.quantize(&x);
+        let mut packed = pq.pack_mse_indices(&idx);
+        packed.pop();
+        let _ = pq.score_ip_encoded_packed(&prep, &packed, &qjl, gamma);
+    }
+
+    #[test]
+    #[should_panic(expected = "qjl.len() must equal ceil(n/8)")]
+    fn score_ip_encoded_panics_on_short_qjl_when_gamma_nonzero() {
+        let pq = make_pq(64);
+        let q: Array1<f64> = Array1::from_elem(64, 0.1);
+        let prep = pq.prepare_ip_query(&q);
+        let x = vec![0.2f32; 64];
+        let (idx, mut qjl, _gamma) = pq.quantize(&x);
+        qjl.pop();
+        let _ = pq.score_ip_encoded(&prep, &idx, &qjl, 1.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "indices.len() must equal quantizer.n")]
+    fn pack_mse_indices_panics_on_short_indices() {
+        let pq = make_pq(64);
+        let short_idx = vec![0 as CodeIndex; pq.n - 1];
+        let _ = pq.pack_mse_indices(&short_idx);
+    }
+
+    #[test]
+    #[should_panic(expected = "packed.len() must equal ceil(n*b/8)")]
+    fn unpack_mse_indices_panics_on_short_packed() {
+        let pq = make_pq(64);
+        let mut out = vec![0 as CodeIndex; pq.n];
+        let packed = vec![0u8; pq.packed_mse_len() - 1];
+        pq.unpack_mse_indices(&packed, &mut out);
+    }
+
+    #[test]
+    #[should_panic(expected = "query_signs.len()*B must equal mse_bytes.len()")]
+    fn hamming_disagree_signs_panics_on_mismatched_lengths() {
+        let query_signs = vec![0u8; 1];
+        let mse_bytes = vec![0u8; 3];
+        let _ = super::hamming_disagree_signs::<2>(&query_signs, &mse_bytes);
+    }
+
+    #[test]
+    fn hamming_proximity_ignores_padding_bits() {
+        let pq = ProdQuantizer::new_dense(10, 4, 42);
+        let from = [0b0000_0000u8, 0b0000_0000u8];
+        let to = [0b0000_0000u8, 0b1111_1100u8];
+        let score = pq.hamming_proximity(&from, &to);
+        assert_eq!(
+            score, 1.0,
+            "padding bits beyond n must not affect proximity"
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "quantize_batch: vector length must equal d")]
+    fn dense_quantize_batch_panics_on_short_vector() {
+        let pq = ProdQuantizer::new_dense(4, 4, 42);
+        let vectors: Vec<Vec<f32>> = (0..64).map(|_| vec![0.1f32; 3]).collect();
+        let refs: Vec<&[f32]> = vectors.iter().map(|v| v.as_slice()).collect();
+        let _ = pq.quantize_batch(&refs);
     }
 
     /// C4: zero vector quantize/dequantize is a no-panic edge case. The result

--- a/src/quantizer/prod.rs
+++ b/src/quantizer/prod.rs
@@ -1203,7 +1203,7 @@ pub fn hamming_disagree_b4_signs(query_signs: &[u8], mse_bytes: &[u8]) -> u32 {
 /// Lower return = closer in IP.
 #[inline]
 pub fn hamming_disagree_signs<const B: usize>(query_signs: &[u8], mse_bytes: &[u8]) -> u32 {
-    assert_eq!(
+    debug_assert_eq!(
         query_signs.len() * B,
         mse_bytes.len(),
         "hamming_disagree_signs<B={B}>: query_signs.len()*B must equal mse_bytes.len()"

--- a/src/quantizer/prod.rs
+++ b/src/quantizer/prod.rs
@@ -612,13 +612,20 @@ impl ProdQuantizer {
         qjl: &[u8],
         gamma: f64,
     ) -> f64 {
-        assert_eq!(
+        debug_assert_eq!(
             packed_mse.len(),
             self.packed_mse_len(),
             "score_ip_encoded_packed: packed_mse.len() must equal ceil(n*b/8) ({})",
             self.packed_mse_len()
         );
-        self.assert_qjl_len_if_used(qjl, gamma, "score_ip_encoded_packed");
+        if gamma != 0.0 {
+            debug_assert_eq!(
+                qjl.len(),
+                self.qjl_len(),
+                "score_ip_encoded_packed: qjl.len() must equal ceil(n/8) ({}) when gamma is non-zero",
+                self.qjl_len()
+            );
+        }
 
         #[cfg(target_arch = "x86_64")]
         {

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -533,7 +533,13 @@ impl TurboQuantEngine {
             let q = load_quantizer_state(local_dir, &backend)?;
             (m, q)
         } else {
-            let qt = quantizer_type.as_deref().unwrap_or("dense");
+            // Auto-select rotation: SRHT at d≥1024 is decisively better on
+            // ingest (2-3×), p50 latency (1.5-3×), and matches/beats dense
+            // Haar QR on recall in our public bench. Dense remains the default
+            // at low dim where SRHT's pow2 padding tax dominates the win.
+            let qt = quantizer_type.as_deref().unwrap_or_else(|| {
+                if d >= 1024 { "srht" } else { "dense" }
+            });
             let is_dense = qt == "dense" || qt == "exact"; // "exact" is a legacy alias
             let q = if is_dense && fast_mode {
                 ProdQuantizer::new_dense_fast(d, b, seed)

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -1170,6 +1170,9 @@ impl TurboQuantEngine {
         include_document: bool,
     ) -> Result<Vec<Vec<SearchResult>>, Box<dyn std::error::Error + Send + Sync>> {
         let nq = queries.len();
+        if top_k == 0 {
+            return Ok(vec![Vec::new(); nq]);
+        }
         let internal_k = top_k; // no rerank — caller already checked rerank_enabled=false
 
         // Apply the same query normalisation as the single-query path.

--- a/src/storage/engine/mod.rs
+++ b/src/storage/engine/mod.rs
@@ -537,9 +537,9 @@ impl TurboQuantEngine {
             // ingest (2-3×), p50 latency (1.5-3×), and matches/beats dense
             // Haar QR on recall in our public bench. Dense remains the default
             // at low dim where SRHT's pow2 padding tax dominates the win.
-            let qt = quantizer_type.as_deref().unwrap_or_else(|| {
-                if d >= 1024 { "srht" } else { "dense" }
-            });
+            let qt = quantizer_type
+                .as_deref()
+                .unwrap_or_else(|| if d >= 1024 { "srht" } else { "dense" });
             let is_dense = qt == "dense" || qt == "exact"; // "exact" is a legacy alias
             let q = if is_dense && fast_mode {
                 ProdQuantizer::new_dense_fast(d, b, seed)
@@ -2294,14 +2294,23 @@ impl TurboQuantEngine {
                     if self.live_vraw.is_some() {
                         // P12: ResidualInt4 uses the additive shortcut to avoid
                         // O(d^2) code re-dequantization per candidate.
-                        if matches!(self.manifest.rerank_precision, RerankPrecision::ResidualInt4)
-                            && !matches!(self.metric, DistanceMetric::L2)
+                        if matches!(
+                            self.manifest.rerank_precision,
+                            RerankPrecision::ResidualInt4
+                        ) && !matches!(self.metric, DistanceMetric::L2)
                         {
                             let q_norm_inv = if matches!(self.metric, DistanceMetric::Cosine) {
                                 let qn = query.iter().map(|x| x * x).sum::<f64>().sqrt();
                                 if qn > 1e-10 { 1.0 / qn } else { 0.0 }
-                            } else { 0.0 };
-                            self.live_rerank_score_residual_int4(slot as usize, query, approx_score, q_norm_inv)
+                            } else {
+                                0.0
+                            };
+                            self.live_rerank_score_residual_int4(
+                                slot as usize,
+                                query,
+                                approx_score,
+                                q_norm_inv,
+                            )
                         } else {
                             let raw_vec = self.live_raw_vector_at_slot(slot as usize);
                             score_vectors_with_metric(&self.metric, query, &raw_vec)
@@ -2589,8 +2598,10 @@ impl TurboQuantEngine {
         const HAMMING_PREFILTER_RETAIN_RATIO: usize = 16; // P4: tightened from 8 -> 16
         let prefilter_b = quantizer.b;
         let prefilter_supports_b = matches!(prefilter_b, 1 | 2 | 4 | 8);
+        let prefilter_layout_ok = quantizer.n.div_ceil(8) * prefilter_b == mse_len;
         let use_sign_prefilter = qjl_len == 0
             && prefilter_supports_b
+            && prefilter_layout_ok
             && quantizer.d >= HAMMING_PREFILTER_MIN_DIM
             && matches!(metric, DistanceMetric::Ip | DistanceMetric::Cosine)
             && candidate_slots.len() >= HAMMING_PREFILTER_MIN_CANDIDATES;
@@ -2991,14 +3002,23 @@ impl TurboQuantEngine {
 
             let score = if self.rerank_enabled {
                 if self.live_vraw.is_some() {
-                    if matches!(self.manifest.rerank_precision, RerankPrecision::ResidualInt4)
-                        && !matches!(self.metric, DistanceMetric::L2)
+                    if matches!(
+                        self.manifest.rerank_precision,
+                        RerankPrecision::ResidualInt4
+                    ) && !matches!(self.metric, DistanceMetric::L2)
                     {
                         let q_norm_inv = if matches!(self.metric, DistanceMetric::Cosine) {
                             let qn = query.iter().map(|x| x * x).sum::<f64>().sqrt();
                             if qn > 1e-10 { 1.0 / qn } else { 0.0 }
-                        } else { 0.0 };
-                        self.live_rerank_score_residual_int4(cand_slot as usize, query, cand_score, q_norm_inv)
+                        } else {
+                            0.0
+                        };
+                        self.live_rerank_score_residual_int4(
+                            cand_slot as usize,
+                            query,
+                            cand_score,
+                            q_norm_inv,
+                        )
                     } else {
                         let raw_vec = self.live_raw_vector_at_slot(cand_slot as usize);
                         score_vectors_with_metric(&self.metric, query, &raw_vec)
@@ -3916,7 +3936,7 @@ impl TurboQuantEngine {
                 let recon = self.quantizer.mse_quantizer.dequantize(&idx);
                 let doc_norm = f32::from_le_bytes(
                     codes_bytes[slot * stride + mse_len + qjl_len + 4
-                              ..slot * stride + mse_len + qjl_len + 8]
+                        ..slot * stride + mse_len + qjl_len + 8]
                         .try_into()
                         .expect("doc_norm field is 4 bytes"),
                 ) as f64;
@@ -3987,7 +4007,9 @@ impl TurboQuantEngine {
         vector: &[f32],
         precomputed_residual: Option<&[f32]>,
     ) {
-        let Some(vraw) = &mut self.live_vraw else { return; };
+        let Some(vraw) = &mut self.live_vraw else {
+            return;
+        };
         let rec = vraw.get_slot_mut(slot as usize);
         match self.manifest.rerank_precision {
             RerankPrecision::Int8 => {
@@ -4023,8 +4045,8 @@ impl TurboQuantEngine {
             }
             RerankPrecision::ResidualInt4 => {
                 // Caller must supply precomputed_residual for this mode.
-                let residual = precomputed_residual
-                    .expect("ResidualInt4 requires precomputed_residual");
+                let residual =
+                    precomputed_residual.expect("ResidualInt4 requires precomputed_residual");
                 let scale = residual
                     .iter()
                     .map(|v| v.abs())
@@ -4116,7 +4138,7 @@ impl TurboQuantEngine {
                     b,
                     1.0,
                     rotation_matrix.as_ptr(),
-                    1, // Q^T: rsa=1
+                    1,          // Q^T: rsa=1
                     d as isize, // Q^T: csa=d
                     y_tilde.as_ptr(),
                     1, // col-major y_tilde
@@ -4198,15 +4220,25 @@ impl TurboQuantEngine {
     }
 
     fn live_residual_score_at_slot(&self, slot: usize, query: &Array1<f64>) -> f64 {
-        let Some(vraw) = &self.live_vraw else { return 0.0; };
+        let Some(vraw) = &self.live_vraw else {
+            return 0.0;
+        };
         let rec = vraw.get_slot(slot);
         let scale = f32::from_le_bytes(rec[..4].try_into().unwrap()) as f64;
         let inv_scale_over_7 = scale / 7.0;
         let mut score = 0.0_f64;
         for i in 0..self.d {
             let byte = rec[4 + i / 2];
-            let nibble = if i % 2 == 0 { byte & 0x0F } else { (byte >> 4) & 0x0F };
-            let signed = if nibble > 7 { nibble as i8 - 16 } else { nibble as i8 };
+            let nibble = if i % 2 == 0 {
+                byte & 0x0F
+            } else {
+                (byte >> 4) & 0x0F
+            };
+            let signed = if nibble > 7 {
+                nibble as i8 - 16
+            } else {
+                nibble as i8
+            };
             let v = signed as f64 * inv_scale_over_7;
             score += query[i] * v;
         }
@@ -4696,7 +4728,8 @@ impl TurboQuantEngine {
             //
             // For non-rerank-stored modes (Disabled) and other precisions this
             // pre-pass is a no-op (vector kept None).
-            let precomputed_residuals: Option<Vec<Vec<f32>>> = match self.manifest.rerank_precision {
+            let precomputed_residuals: Option<Vec<Vec<f32>>> = match self.manifest.rerank_precision
+            {
                 RerankPrecision::ResidualInt4 if self.live_vraw.is_some() => {
                     // For ResidualInt4 the residual is computed against the
                     // vector that's actually stored: vec_unit when normalize=True,
@@ -4704,16 +4737,16 @@ impl TurboQuantEngine {
                     let store_refs: Vec<&[f32]> = unit_vecs_and_norms
                         .iter()
                         .enumerate()
-                        .map(|(i, (uv, _))| if self.normalize {
-                            uv.as_slice()
-                        } else {
-                            chunk[i].vector.as_slice()
+                        .map(|(i, (uv, _))| {
+                            if self.normalize {
+                                uv.as_slice()
+                            } else {
+                                chunk[i].vector.as_slice()
+                            }
                         })
                         .collect();
-                    let all_idx: Vec<Vec<CodeIndex>> = quantized
-                        .iter()
-                        .map(|(idx, _, _)| idx.clone())
-                        .collect();
+                    let all_idx: Vec<Vec<CodeIndex>> =
+                        quantized.iter().map(|(idx, _, _)| idx.clone()).collect();
                     Some(self.compute_residuals_batch_parallel(&store_refs, &all_idx))
                 }
                 _ => None,
@@ -4760,9 +4793,7 @@ impl TurboQuantEngine {
                     entry.gamma,
                     stored_norm,
                 )?;
-                let precomputed = precomputed_residuals
-                    .as_ref()
-                    .map(|all| all[_i].as_slice());
+                let precomputed = precomputed_residuals.as_ref().map(|all| all[_i].as_slice());
                 self.live_save_raw_vector_with_residual(slot, raw_for_rerank, precomputed);
                 touched_slots.push(slot);
                 if has_meaningful_metadata(&meta) {

--- a/src/storage/engine/tests.rs
+++ b/src/storage/engine/tests.rs
@@ -166,6 +166,31 @@ fn cosine_zero_norm_vector_scores_zero() {
     assert_eq!(results[0].score, 0.0);
 }
 
+#[test]
+fn score_batch_brute_top_k_zero_returns_empty_rows() {
+    let dir = tempdir().unwrap();
+    let p = dir.path().to_str().unwrap();
+    let d = 8;
+    let mut e = TurboQuantEngine::open_with_metric_and_rerank(
+        p,
+        p,
+        d,
+        2,
+        42,
+        DistanceMetric::Ip,
+        false,
+        false,
+    )
+    .unwrap();
+    e.insert("a".into(), &make_vec(d, 0.5), no_meta()).unwrap();
+    let queries = vec![make_vec(d, 0.1), make_vec(d, 0.2)];
+    let rows = e
+        .score_batch_brute(&queries, 0, None, true, true, true)
+        .unwrap();
+    assert_eq!(rows.len(), queries.len());
+    assert!(rows.iter().all(|row| row.is_empty()));
+}
+
 // ── L2 exhaustive search ───────────────────────────────────────────────
 
 #[test]

--- a/src/storage/engine/tests.rs
+++ b/src/storage/engine/tests.rs
@@ -623,18 +623,39 @@ fn residual_int4_reload_preserves_recall() {
     let v: Vec<f64> = (0..d).map(|i| (i as f64 * 0.013).sin()).collect();
     {
         let mut e = TurboQuantEngine::open_with_options(
-            p, p, d, 4, 42,
-            DistanceMetric::Ip, true, false,
-            RerankPrecision::ResidualInt4, None, false, None,
-        ).unwrap();
-        e.insert("v1".into(), &Array1::from_vec(v.clone()), no_meta()).unwrap();
+            p,
+            p,
+            d,
+            4,
+            42,
+            DistanceMetric::Ip,
+            true,
+            false,
+            RerankPrecision::ResidualInt4,
+            None,
+            false,
+            None,
+        )
+        .unwrap();
+        e.insert("v1".into(), &Array1::from_vec(v.clone()), no_meta())
+            .unwrap();
         e.checkpoint().unwrap();
     }
     let e = TurboQuantEngine::open_with_options(
-        p, p, d, 4, 42,
-        DistanceMetric::Ip, true, false,
-        RerankPrecision::ResidualInt4, None, false, None,
-    ).unwrap();
+        p,
+        p,
+        d,
+        4,
+        42,
+        DistanceMetric::Ip,
+        true,
+        false,
+        RerankPrecision::ResidualInt4,
+        None,
+        false,
+        None,
+    )
+    .unwrap();
     let results = e
         .search_with_filter_and_ann(&Array1::from_vec(v), 1, None, None, false, None)
         .unwrap();

--- a/tests/test_async_api.py
+++ b/tests/test_async_api.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 import pytest
@@ -110,44 +111,38 @@ async def test_get_and_metadata_update(tmp_db_path):
 
 @pytest.mark.asyncio
 async def test_concurrent_searches_dont_serialize(tmp_db_path):
-    """Fire 50 concurrent searches and confirm they don't run sequentially.
+    """Concurrent awaits should fan out through the executor.
 
-    The expected wall-clock is much less than (n_tasks × per-task latency);
-    if the wrapper accidentally serialized, total time would scale linearly
-    with task count.
+    Use a tiny blocking fake DB instead of timing real Rust searches. The real
+    search path can be sub-millisecond on small corpora, making ratio checks
+    mostly scheduler noise rather than a test of the Python wrapper.
     """
-    d = 64
-    async with await AsyncDatabase.open(tmp_db_path, dimension=d, bits=4) as db:
-        # Populate with enough data that each search isn't a sub-microsecond no-op.
-        ids = [f"d{i}" for i in range(2_000)]
-        vecs = np.stack([_vec(d, i) for i in range(2_000)])
-        await db.insert_batch(ids, vecs, None, None, "insert")
 
-        # Warm-up so the first call's overhead doesn't skew the median.
-        await db.search(_vec(d, 0), top_k=10)
+    class _SleepyDb:
+        def search(self, query, top_k):
+            time.sleep(0.02)
+            return [{"id": str(query), "score": 1.0}]
 
-        # Time a single search to set the bar.
+        def close(self):
+            return None
+
+    pool = ThreadPoolExecutor(max_workers=8)
+    db = AsyncDatabase(_SleepyDb(), executor=pool, owns_executor=True)
+    try:
+        n_tasks = 16
         t0 = time.perf_counter()
-        await db.search(_vec(d, 0), top_k=10)
-        single_s = max(time.perf_counter() - t0, 1e-4)
-
-        # Fire many concurrent searches.
-        n_tasks = 50
-        t0 = time.perf_counter()
-        await asyncio.gather(
-            *(db.search(_vec(d, i), top_k=10) for i in range(n_tasks))
+        results = await asyncio.gather(
+            *(db.search(i, top_k=1) for i in range(n_tasks))
         )
-        concurrent_s = time.perf_counter() - t0
+        elapsed = time.perf_counter() - t0
 
-        # Sequential would take ~ n_tasks × single_s. Concurrent should be
-        # WAY less — we accept up to a generous 0.5 × that as proof of
-        # parallelism (covers slow CI / Windows scheduler jitter).
-        sequential_estimate = n_tasks * single_s
-        assert concurrent_s < 0.5 * sequential_estimate, (
-            f"50 concurrent searches took {concurrent_s:.3f}s; sequential "
-            f"would be ~{sequential_estimate:.3f}s. The wrapper appears to "
-            f"serialize."
+        assert len(results) == n_tasks
+        assert elapsed < 0.20, (
+            f"{n_tasks} executor-backed searches took {elapsed:.3f}s; "
+            "the wrapper appears to serialize."
         )
+    finally:
+        await db.close()
 
 
 @pytest.mark.asyncio

--- a/tests/test_chroma_compat.py
+++ b/tests/test_chroma_compat.py
@@ -174,6 +174,17 @@ class TestGet:
         assert res["metadatas"] is not None
         assert res["documents"] is None
 
+    def test_get_empty_collection_honors_include_shape(self, tmp_path):
+        client = PersistentClient(str(tmp_path))
+        col = client.get_or_create_collection("col")
+        res = col.get(include=["embeddings"])
+        assert res == {
+            "ids": [],
+            "metadatas": None,
+            "documents": None,
+            "embeddings": [],
+        }
+
 
 # ---------------------------------------------------------------------------
 # query
@@ -220,6 +231,16 @@ class TestQuery:
         with pytest.raises(NotImplementedError):
             col.query(query_embeddings=[rand_vecs(1)[0]], where_document={"$contains": "hi"})
 
+    def test_query_empty_collection_returns_nested_empty_results(self, tmp_path):
+        client = PersistentClient(str(tmp_path))
+        col = client.get_or_create_collection("col")
+        res = col.query(query_embeddings=rand_vecs(2), n_results=3)
+        assert res["ids"] == [[], []]
+        assert res["distances"] == [[], []]
+        assert res["metadatas"] == [[], []]
+        assert res["documents"] == [[], []]
+        assert res["embeddings"] is None
+
 
 # ---------------------------------------------------------------------------
 # delete / upsert / update
@@ -245,6 +266,13 @@ class TestMutations:
         res = col.get()
         assert "a" not in res["ids"]
         assert "b" in res["ids"]
+
+    def test_delete_empty_collection_is_noop(self, tmp_path):
+        client = PersistentClient(str(tmp_path))
+        col = client.get_or_create_collection("col")
+        col.delete(ids=["missing"])
+        col.delete(where={"tag": {"$eq": "missing"}})
+        assert col.count() == 0
 
     def test_upsert_inserts_new(self, tmp_path):
         client = PersistentClient(str(tmp_path))

--- a/tests/test_chroma_compat_coverage.py
+++ b/tests/test_chroma_compat_coverage.py
@@ -610,27 +610,42 @@ class TestDeleteWithIdsAndWhere:
 
 
 # ===========================================================================
-# CompatCollection.get — line 296 (no manifest → early empty return)
+# CompatCollection.get — no manifest -> early empty return
 # ===========================================================================
 
 class TestGetNoManifest:
     def test_get_returns_empty_dict_when_no_manifest(self, tmp_path):
-        """Line 296: get() returns empty result dict when manifest.json absent."""
+        """get() returns an empty result dict when manifest.json is absent."""
         col = CompatCollection(str(tmp_path / "col"), "col", "ip")
         result = col.get()
-        assert result == {"ids": [], "metadatas": [], "documents": []}
+        assert result == {
+            "ids": [],
+            "metadatas": [],
+            "documents": [],
+            "embeddings": None,
+        }
 
     def test_get_with_ids_returns_empty_when_no_manifest(self, tmp_path):
-        """Line 296: get(ids=...) also returns empty when no manifest.json exists."""
+        """get(ids=...) also returns empty when manifest.json is absent."""
         col = CompatCollection(str(tmp_path / "col"), "col", "ip")
         result = col.get(ids=["a", "b"])
-        assert result == {"ids": [], "metadatas": [], "documents": []}
+        assert result == {
+            "ids": [],
+            "metadatas": [],
+            "documents": [],
+            "embeddings": None,
+        }
 
     def test_get_with_where_returns_empty_when_no_manifest(self, tmp_path):
-        """Line 296: get(where=...) also returns empty when no manifest.json."""
+        """get(where=...) also returns empty when manifest.json is absent."""
         col = CompatCollection(str(tmp_path / "col"), "col", "ip")
         result = col.get(where={"x": {"$eq": 1}})
-        assert result == {"ids": [], "metadatas": [], "documents": []}
+        assert result == {
+            "ids": [],
+            "metadatas": [],
+            "documents": [],
+            "embeddings": None,
+        }
 
 
 # ===========================================================================

--- a/tests/test_lancedb_compat.py
+++ b/tests/test_lancedb_compat.py
@@ -155,6 +155,19 @@ class TestSearch:
         arrow_tbl = tbl.search(q).limit(2).to_arrow()
         assert arrow_tbl.num_rows == 2
 
+    def test_limit_zero_returns_empty_for_vector_and_scan(self, tmp_path):
+        db = connect(str(tmp_path))
+        tbl = db.create_table("t", data=make_rows(2))
+        q = rand_vecs(1)[0].astype(np.float32)
+        assert tbl.search(q).limit(0).to_list() == []
+        assert tbl.search(None).limit(0).to_list() == []
+
+    def test_empty_table_search_returns_empty(self, tmp_path):
+        db = connect(str(tmp_path))
+        tbl = db.create_table("t")
+        assert tbl.search(None).limit(5).to_list() == []
+        assert tbl.search(rand_vecs(1)[0]).limit(5).to_list() == []
+
 
 # ---------------------------------------------------------------------------
 # where filter
@@ -281,6 +294,11 @@ class TestSQLParser:
         from tqdb.lancedb_compat import _parse_sql_where
         result = _parse_sql_where("count = 42")
         assert result == {"count": {"$eq": 42.0}}
+
+    def test_field_eq_negative_number(self):
+        from tqdb.lancedb_compat import _parse_sql_where
+        result = _parse_sql_where("score = -1")
+        assert result == {"score": {"$eq": -1.0}}
 
     def test_field_gt_numeric(self):
         from tqdb.lancedb_compat import _parse_sql_where

--- a/tests/test_multivector.py
+++ b/tests/test_multivector.py
@@ -99,6 +99,23 @@ def test_insert_replaces_existing_doc():
             store._db.close()
 
 
+def test_failed_replace_keeps_existing_doc():
+    d = 8
+    with _tempdir() as path:
+        store = MultiVectorStore.open(path, dimension=d, bits=2, metric="cosine")
+        try:
+            store.insert("x", _doc_tokens(d, 3, 1), document="v1")
+            with pytest.raises(ValueError, match="dimension mismatch"):
+                store.insert("x", np.zeros((2, d - 1), dtype=np.float32))
+
+            info = store.get("x")
+            assert info is not None
+            assert info["document"] == "v1"
+            assert len(store) == 1
+        finally:
+            store._db.close()
+
+
 def test_delete_removes_doc():
     d = 8
     with _tempdir() as path:


### PR DESCRIPTION
## Summary
- merge the Rust, Python API, CI/packaging, and docs audit fixes
- keep this as enhancement/fix hardening work, not a 0.9.0 release
- remove version-specific v0.9 wording from docs and branch-visible artifacts

## Verification
- unit PRs were monitored through CI and review comments before merge
- docs/correction PRs were monitored through CI and review comments before merge
- final grep leaves only third-party Cargo.lock dependency versions for 0.9.0