### PR TITLE
[codex] bump patch version to 0.8.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+---
+
+## [0.8.4] — 2026-05-19
+
 ### Changed
 
 - **`quantizer_type=None` default is now dimension-aware.** Picks `"dense"` (Haar QR) for `d < 1024` and `"srht"` (Walsh–Hadamard) for `d >= 1024`. Empirical wins for SRHT once the rotation dominates ingest/latency cost: 2–3× ingest throughput, 1.5–3× lower p50 latency, recall equal or slightly better than dense in the public bench (R@1 0.962 vs 0.958 at d=1536 b=4 rerank=F; 0.980 vs 0.963 at d=3072 b=4 rerank=F). Below d=1024 the SRHT pow2-padding tax wipes the win so dense remains the default. To restore explicit control, pass `quantizer_type="dense"` or `quantizer_type="srht"`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2108,7 +2108,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tqdb"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "bincode",
  "crc32fast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tqdb"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2024"
 license = "Apache-2.0"
 description = "Embedded vector database with zero-training-time two-stage quantization (TurboQuant)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "tqdb"
-version = "0.8.3"
+version = "0.8.4"
 description = "Embedded vector database using the TurboQuant algorithm (arXiv:2504.19874) — zero training, 2-4 bit compression, fast inner-product search"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -1678,7 +1678,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tqdb"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "bincode",
  "crc32fast",


### PR DESCRIPTION
## Summary
- bump Rust crate and Python package metadata to 0.8.4
- move current changelog entries under 0.8.4 dated 2026-05-19
- keep this as an enhancement/fix patch release, not 0.9.0

## Note
Direct push to main is blocked by repository rules requiring PRs, so this bump is submitted as a PR despite the release-bump convention.

## Verification
- cargo check -q
- git diff --check
- release-number grep leaves only third-party Cargo.lock dependency versions for 0.9.0